### PR TITLE
Cache bank/preset lists to prevent glitchy playback when switching channels

### DIFF
--- a/zynqtgui/sketchpad/sketchpad_channel.py
+++ b/zynqtgui/sketchpad/sketchpad_channel.py
@@ -192,8 +192,6 @@ class sketchpad_channel(QObject):
         # Back up curlayer
         curlayer = self.zynqtgui.curlayer
 
-        logging.debug(f"curlayer before cache : curLayer({curlayer}), chainedSounds({self.chainedSounds}), layer_midi_map({self.zynqtgui.layer.layer_midi_map})")
-
         for midi_channel in self.chainedSounds:
             if midi_channel >= 0 and self.checkIfLayerExists(midi_channel):
                 # Change curlayer to synth's layer and fill back/preset list

--- a/zynqtgui/sketchpad/sketchpad_channel.py
+++ b/zynqtgui/sketchpad/sketchpad_channel.py
@@ -203,6 +203,8 @@ class sketchpad_channel(QObject):
 
         # Restore curlayer
         self.zynqtgui.curlayer = curlayer
+        self.zynqtgui.bank.fill_list()
+        self.zynqtgui.preset.fill_list()
 
     def update_filter_controllers(self):
         for index, midi_channel in enumerate(self.chainedSounds):

--- a/zynqtgui/sketchpad/sketchpad_channel.py
+++ b/zynqtgui/sketchpad/sketchpad_channel.py
@@ -173,6 +173,7 @@ class sketchpad_channel(QObject):
         self.selectedPartNamesChanged.emit()
 
     def chained_sounds_changed_handler(self):
+        self.cache_bank_preset_lists()
         self.update_filter_controllers()
         self.zynqtgui.zynautoconnect()
         self.occupiedSlotsChanged.emit()
@@ -186,6 +187,24 @@ class sketchpad_channel(QObject):
         self.connectedSoundNameChanged.emit()
         self.chainedSoundsInfoChanged.emit()
         self.chainedSoundsNamesChanged.emit()
+
+    def cache_bank_preset_lists(self):
+        # Back up curlayer
+        curlayer = self.zynqtgui.curlayer
+
+        logging.debug(f"curlayer before cache : curLayer({curlayer}), chainedSounds({self.chainedSounds}), layer_midi_map({self.zynqtgui.layer.layer_midi_map})")
+
+        for midi_channel in self.chainedSounds:
+            if midi_channel >= 0 and self.checkIfLayerExists(midi_channel):
+                # Change curlayer to synth's layer and fill back/preset list
+                self.zynqtgui.curlayer = self.zynqtgui.layer.layer_midi_map[midi_channel]
+                logging.debug(f"Caching midi channel : channel({midi_channel}), layer({self.zynqtgui.curlayer})")
+                self.zynqtgui.currentTaskMessage = f"Caching bank/preset lists for Channel {self.name}"
+                self.zynqtgui.bank.fill_list()
+                self.zynqtgui.preset.fill_list()
+
+        # Restore curlayer
+        self.zynqtgui.curlayer = curlayer
 
     def update_filter_controllers(self):
         for index, midi_channel in enumerate(self.chainedSounds):

--- a/zynqtgui/zynthian_gui_bank.py
+++ b/zynqtgui/zynthian_gui_bank.py
@@ -60,17 +60,10 @@ class zynthian_gui_bank(zynthian_gui_selector):
         self.__show_top_sounds = False
         self.auto_next_screen = False
         self.__list_data_cache = {}
-        self.__list_timer = QTimer()
-        self.__list_timer.setInterval(100)
-        self.__list_timer.setSingleShot(True)
-        self.__list_timer.timeout.connect(self.fill_list_actual)
         self.show()
 
 
     def fill_list(self):
-        self.__list_timer.start()
-
-    def fill_list_actual(self):
         self.list_data = []
 
         if not self.zynqtgui.curlayer:

--- a/zynqtgui/zynthian_gui_bank.py
+++ b/zynqtgui/zynthian_gui_bank.py
@@ -71,30 +71,20 @@ class zynthian_gui_bank(zynthian_gui_selector):
             super().fill_list()
             return
 
-        # Filling bank list requires reading from quite some files.
-        # Too much file IO causes jackd thread to be not scheduled which causes XRUNS which in turn causes glitchiness during playback
-        # Instead of reading files every run, cache the data.
-        # Since bank data of a synth should not change while the application is running, it should be fairly safe to cache the data
-        if self.zynqtgui.curlayer in self.__list_data_cache:
-            logging.debug("Bank list cached")
-            self.list_data = self.__list_data_cache[self.zynqtgui.curlayer]
+        if self.__show_top_sounds:
+            self.zynqtgui.screens['preset'].reload_top_sounds()
+            top_sounds = self.zynqtgui.screens['preset'].get_all_top_sounds()
+            for engine in top_sounds:
+                parts = engine.split("/")
+                readable_name = engine
+                if len(parts) > 1:
+                    readable_name = parts[1]
+                if len(top_sounds[engine]) > 0:
+                    self.list_data.append((engine, len(self.list_data), "{} ({})".format(readable_name, len(top_sounds[engine]))))
+            self.list_data = sorted(self.list_data, key=cmp_to_key(customSort))
         else:
-            logging.debug("Bank list not cached")
-            if self.__show_top_sounds:
-                self.zynqtgui.screens['preset'].reload_top_sounds()
-                top_sounds = self.zynqtgui.screens['preset'].get_all_top_sounds()
-                for engine in top_sounds:
-                    parts = engine.split("/")
-                    readable_name = engine
-                    if len(parts) > 1:
-                        readable_name = parts[1]
-                    if len(top_sounds[engine]) > 0:
-                        self.list_data.append((engine, len(self.list_data), "{} ({})".format(readable_name, len(top_sounds[engine]))))
-                self.list_data = sorted(self.list_data, key=cmp_to_key(customSort))
-            else:
-                self.zynqtgui.curlayer.load_bank_list()
-                self.list_data = self.zynqtgui.curlayer.bank_list
-            self.__list_data_cache[self.zynqtgui.curlayer] = self.list_data
+            self.zynqtgui.curlayer.load_bank_list()
+            self.list_data = self.zynqtgui.curlayer.bank_list
 
         self.zynqtgui.screens['preset'].set_select_path()
         super().fill_list()

--- a/zynqtgui/zynthian_gui_bank.py
+++ b/zynqtgui/zynthian_gui_bank.py
@@ -127,7 +127,7 @@ class zynthian_gui_bank(zynthian_gui_selector):
             super().show()
             return
         if not self.zynqtgui.curlayer:
-            logging.info("Can't show bank list for None layer!")
+            logging.debug("Can't show bank list for None layer!")
             super().show()
             return
         if not self.zynqtgui.curlayer.get_bank_name():

--- a/zynqtgui/zynthian_gui_preset.py
+++ b/zynqtgui/zynthian_gui_preset.py
@@ -62,17 +62,10 @@ class zynthian_gui_preset(zynthian_gui_selector):
         self.__select_in_progess = False
         self.__list_data_cache = {}
         self.__list_metadata_cache = {}
-        self.__list_timer = QTimer()
-        self.__list_timer.setInterval(100)
-        self.__list_timer.setSingleShot(True)
-        self.__list_timer.timeout.connect(self.fill_list_actual)
         self.show()
 
 
     def fill_list(self):
-        self.__list_timer.start()
-
-    def fill_list_actual(self):
         self.list_data = []
         self.list_metadata = []
 

--- a/zynqtgui/zynthian_gui_preset.py
+++ b/zynqtgui/zynthian_gui_preset.py
@@ -79,16 +79,18 @@ class zynthian_gui_preset(zynthian_gui_selector):
             super().fill_list()
             return
 
-        curlayer_bank_index = self.zynqtgui.curlayer.bank_info[1]
+        curlayer_bank = self.zynqtgui.curlayer.bank_info[2]
+
+        logging.debug(f">>> curlayer_bank_info({self.zynqtgui.curlayer.bank_info}), curlayer_bank({curlayer_bank})")
 
         # Filling preset list requires reading from quite some files.
         # Too much file IO causes jackd thread to be not scheduled which causes XRUNS which in turn causes glitchiness during playback
         # Instead of reading files every run, cache the data.
         # Since preset data of a synth should not change while the application is running, it should be fairly safe to cache the data
-        if self.zynqtgui.curlayer in self.__list_data_cache and curlayer_bank_index in self.__list_data_cache[self.zynqtgui.curlayer]:
+        if self.zynqtgui.curlayer in self.__list_data_cache and curlayer_bank in self.__list_data_cache[self.zynqtgui.curlayer]:
             # Preset list already cached. Return cached data
-            self.list_data = self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank_index]
-            self.list_metadata = self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank_index]
+            self.list_data = self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank]
+            self.list_metadata = self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank]
         else:
             # Preset list not cached. Fetch data and cache
             if self.__top_sounds_engine != None:
@@ -114,8 +116,8 @@ class zynthian_gui_preset(zynthian_gui_selector):
             if self.zynqtgui.curlayer not in self.__list_data_cache:
                 self.__list_data_cache[self.zynqtgui.curlayer] = {}
                 self.__list_metadata_cache[self.zynqtgui.curlayer] = {}
-            self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank_index] = self.list_data
-            self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank_index] = self.list_metadata
+            self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank] = self.list_data
+            self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank] = self.list_metadata
 
         super().fill_list()
         self.set_select_path()

--- a/zynqtgui/zynthian_gui_preset.py
+++ b/zynqtgui/zynthian_gui_preset.py
@@ -113,7 +113,7 @@ class zynthian_gui_preset(zynthian_gui_selector):
 
     def show(self, show_fav_presets=None):
         if not self.zynqtgui.curlayer:
-            logging.info("Can't show preset list for None layer!")
+            logging.debug("Can't show preset list for None layer!")
             return
 
         if self.__top_sounds_engine != None:

--- a/zynqtgui/zynthian_gui_preset.py
+++ b/zynqtgui/zynthian_gui_preset.py
@@ -79,19 +79,18 @@ class zynthian_gui_preset(zynthian_gui_selector):
             super().fill_list()
             return
 
-        # logging.debug(f">>>>> curlayer({self.zynqtgui.curlayer}), bank_index({self.zynqtgui.bank.current_index}), cached({self.zynqtgui.curlayer in self.__list_data_cache and self.zynqtgui.bank.current_index in self.__list_data_cache[self.zynqtgui.curlayer]})")
+        curlayer_bank_index = self.zynqtgui.curlayer.bank_info[1]
 
         # Filling preset list requires reading from quite some files.
         # Too much file IO causes jackd thread to be not scheduled which causes XRUNS which in turn causes glitchiness during playback
         # Instead of reading files every run, cache the data.
         # Since preset data of a synth should not change while the application is running, it should be fairly safe to cache the data
-        if self.zynqtgui.curlayer in self.__list_data_cache and self.zynqtgui.bank.current_index in self.__list_data_cache[self.zynqtgui.curlayer]:
-            logging.debug("Preset list cached")
-            self.list_data = self.__list_data_cache[self.zynqtgui.curlayer][self.zynqtgui.bank.current_index]
-            self.list_metadata = self.__list_metadata_cache[self.zynqtgui.curlayer][self.zynqtgui.bank.current_index]
-            # logging.debug(f">>>>>> Cached data : curlayer({self.zynqtgui.curlayer}), bank_index({self.zynqtgui.bank.current_index}), cache: {self.__list_data_cache[self.zynqtgui.curlayer][self.zynqtgui.bank.current_index]}")
+        if self.zynqtgui.curlayer in self.__list_data_cache and curlayer_bank_index in self.__list_data_cache[self.zynqtgui.curlayer]:
+            # Preset list already cached. Return cached data
+            self.list_data = self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank_index]
+            self.list_metadata = self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank_index]
         else:
-            logging.debug("Preset list not cached")
+            # Preset list not cached. Fetch data and cache
             if self.__top_sounds_engine != None:
                 self.reload_top_sounds()
                 if isinstance(self.__top_sounds, dict) and self.__top_sounds_engine in self.__top_sounds:
@@ -115,8 +114,8 @@ class zynthian_gui_preset(zynthian_gui_selector):
             if self.zynqtgui.curlayer not in self.__list_data_cache:
                 self.__list_data_cache[self.zynqtgui.curlayer] = {}
                 self.__list_metadata_cache[self.zynqtgui.curlayer] = {}
-            self.__list_data_cache[self.zynqtgui.curlayer][self.zynqtgui.bank.current_index] = self.list_data
-            self.__list_metadata_cache[self.zynqtgui.curlayer][self.zynqtgui.bank.current_index] = self.list_metadata
+            self.__list_data_cache[self.zynqtgui.curlayer][curlayer_bank_index] = self.list_data
+            self.__list_metadata_cache[self.zynqtgui.curlayer][curlayer_bank_index] = self.list_metadata
 
         super().fill_list()
         self.set_select_path()

--- a/zynthian_qt_gui.py
+++ b/zynthian_qt_gui.py
@@ -3380,6 +3380,8 @@ class zynthian_gui(QObject):
             # Allow jack ports connection to complete before showing UI
             # so do not update jack ports in a thread
             channel.update_jack_port(run_in_thread=False)
+            # Cache back/preset of all selected synths of all channel
+            channel.cache_bank_preset_lists()
 
         self.zynautoconnect(True)
 


### PR DESCRIPTION
When channel is switched while playing back, there was some hear able glitches during playback. Playback had stutters as well as missing notes when switching channels.

While working on this issue found out that bank/preset has a lot of File IO operation when channel is being switched. For every channel switch (midi channel switch), bank/preset list was bein populated by reading from files which, for obvious reasons, is very expensive.

File IO was causing jackd to not get scheduled while files were being read and hence causing XRUNS which in turn was causing stutters and missing notes during playback.

As suggested by @leinir, this PR fixes the issue by caching bank/preset lists so that while switching channels it does not do any File IO operations. 

Bank/Preset lists is cached when :
  - Starting up UI 
  - Chained sounds of a channel changes (Synth is added or removed)