### PR TITLE
Rework how FX work wrt track and synths

### DIFF
--- a/qml-ui/pages/FXSetupPage.qml
+++ b/qml-ui/pages/FXSetupPage.qml
@@ -34,8 +34,8 @@ Zynthian.MultiSelectorPage {
     id: root
 
 
-    screenIds: ["layer_effects", "effect_types", "layer_effect_chooser"]
-    screenTitles: [qsTr("Active FX (%1)").arg(zynqtgui.layer_effects.effective_count || qsTr("None")), qsTr("FX Type (%1)").arg(zynqtgui.effect_types.effective_count), qsTr("FX (%1)").arg(zynqtgui.layer_effect_chooser.effective_count)]
+    screenIds: ["effect_types", "layer_effect_chooser", ""]
+    screenTitles: [qsTr("FX Type (%1)").arg(zynqtgui.effect_types.effective_count), qsTr("FX (%1)").arg(zynqtgui.layer_effect_chooser.effective_count), ""]
 
     previousScreen: "preset"
 

--- a/qml-ui/pages/Sketchpad/MixedChannelsViewBar.qml
+++ b/qml-ui/pages/Sketchpad/MixedChannelsViewBar.qml
@@ -645,11 +645,7 @@ Rectangle {
                                     target: fxRepeater
                                     property: "fxData"
                                     delayed: true
-                                    value: [root.selectedChannel.getEffectsNameByMidiChannel(root.selectedChannel.chainedSounds[0]),
-                                            root.selectedChannel.getEffectsNameByMidiChannel(root.selectedChannel.chainedSounds[1]),
-                                            root.selectedChannel.getEffectsNameByMidiChannel(root.selectedChannel.chainedSounds[2]),
-                                            root.selectedChannel.getEffectsNameByMidiChannel(root.selectedChannel.chainedSounds[3]),
-                                            root.selectedChannel.getEffectsNameByMidiChannel(root.selectedChannel.chainedSounds[4])]
+                                    value: root.selectedChannel.chainedFxNames
                                 }
 
                                 Repeater {
@@ -719,6 +715,8 @@ Rectangle {
 
                                                     if (root.selectedChannel.selectedFxSlotRow !== index) {
                                                         root.selectedChannel.selectedFxSlotRow = index
+                                                    } else {
+                                                        bottomStack.slotsBar.handleItemClick("fx")
                                                     }
                                                 }
                                             }

--- a/qml-ui/pages/Sketchpad/SlotsBar.qml
+++ b/qml-ui/pages/Sketchpad/SlotsBar.qml
@@ -220,29 +220,30 @@ Rectangle {
             } else {
                 layerSetupDialog.open()
             }
-        } else if (fxButton.checked) {
+        } else if (fxButton.checked || type === "fx") {
             // Clicked entry is fx
             console.log("handleItemClick : FX")
-            fxSetupDialog.open()
 
 //            var chainedSound = root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedFxSlotRow]
 
-//            if (zynqtgui.backButtonPressed) {
+            if (zynqtgui.backButtonPressed) {
 //                // Back is pressed. Clear Slot
+                root.selectedSlotRowItem.channel.removeSelectedFxFromChain()
 //                if (root.selectedSlotRowItem.channel.checkIfLayerExists(chainedSound)) {
 //                    zynqtgui.start_loading()
 //                    zynqtgui.fixed_layers.activate_index(chainedSound)
 //                    zynqtgui.layer_effects.fx_reset_confirmed()
 //                    zynqtgui.stop_loading()
 //                }
-//            } else {
+            } else {
+                fxSetupDialog.open()
 //                zynqtgui.fixed_layers.activate_index(chainedSound)
 //                zynqtgui.layer_options.show();
 //                var screenBack = zynqtgui.current_screen_id;
 //                zynqtgui.current_screen_id = "layer_effects";
 //                root.openBottomDrawerOnLoad = true;
 //                zynqtgui.forced_screen_back = screenBack;
-//            }
+            }
         } else if (samplesButton.checked || type === "sample-trig" || type === "sample-slice") {
             // Clicked entry is samples
             console.log("handleItemClick : Samples")
@@ -527,8 +528,8 @@ Rectangle {
                                             Rectangle {
                                                 property string text: synthsButton.checked && channelDelegate.channel.chainedSounds[index] > -1 && channelDelegate.channel.checkIfLayerExists(channelDelegate.channel.chainedSounds[index])
                                                                         ? channelDelegate.channel.getLayerNameByMidiChannel(channelDelegate.channel.chainedSounds[index]).split(">")[0]
-                                                                        : fxButton.checked && channelDelegate.channel.chainedSounds[index] > -1 && channelDelegate.channel.checkIfLayerExists(channelDelegate.channel.chainedSounds[index])
-                                                                            ? channelDelegate.channel.getEffectsNameByMidiChannel(channelDelegate.channel.chainedSounds[index])
+                                                                        : fxButton.checked
+                                                                            ? channelDelegate.channel.chainedFxNames[index]
                                                                             : samplesButton.checked && channelDelegate.channel.samples[index].path
                                                                                 ? channelDelegate.channel.samples[index].path.split("/").pop()
                                                                                 : ""
@@ -650,8 +651,8 @@ Rectangle {
                             text: root.selectedSlotRowItem
                                       ? synthsButton.checked && root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow] > -1 && root.selectedSlotRowItem.channel.checkIfLayerExists(root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow])
                                           ? root.selectedSlotRowItem.channel.getLayerNameByMidiChannel(root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow]).split(">")[0]
-                                          : fxButton.checked && root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow] > -1 && root.selectedSlotRowItem.channel.checkIfLayerExists(root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow])
-                                              ? root.selectedSlotRowItem.channel.getEffectsNameByMidiChannel(root.selectedSlotRowItem.channel.chainedSounds[root.selectedSlotRowItem.channel.selectedSlotRow])
+                                          : fxButton.checked
+                                              ? root.selectedSlotRowItem.channel.chainedFxNames[root.selectedSlotRowItem.channel.selectedFxSlotRow]
                                               : samplesButton.checked && root.selectedSlotRowItem.channel.samples[root.selectedSlotRowItem.channel.selectedSlotRow].path
                                                   ? root.selectedSlotRowItem.channel.samples[root.selectedSlotRowItem.channel.selectedSlotRow].path.split("/").pop()
                                                   : ""
@@ -819,19 +820,28 @@ Rectangle {
 
     Zynthian.ActionPickerPopup {
         id: fxSetupDialog
+        property var selectedFx: root.selectedSlotRowItem.channel.chainedFx[root.selectedSlotRowItem.channel.selectedFxSlotRow]
 
         actions: [
-            QQC2.Action {
-                text: qsTr("Pick FX")
+            Kirigami.Action {
+                text: fxSetupDialog.selectedFx == null
+                        ? qsTr("Pick FX")
+                        : qsTr("Change FX")
+                onTriggered: {
+                    zynqtgui.forced_screen_back = "sketchpad"
+                    zynqtgui.current_screen_id = "effect_types"
+                }
             },
-            QQC2.Action {
-                text: qsTr("Change FX")
-            },
-            QQC2.Action {
+            Kirigami.Action {
                 text: qsTr("Remove FX")
+                visible: fxSetupDialog.selectedFx != null
+                onTriggered: {
+                    root.selectedSlotRowItem.channel.removeSelectedFxFromChain()
+                }
             },
-            QQC2.Action {
+            Kirigami.Action {
                 text: qsTr("Edit FX")
+                visible: false
             }
         ]
     }

--- a/zynautoconnect/zynthian_autoconnect.py
+++ b/zynautoconnect/zynthian_autoconnect.py
@@ -730,10 +730,16 @@ def audio_autoconnect(force=False):
     ### BEGIN Disconnect all ports of SynthPassthrough
     for input_port in jclient.get_ports("SynthPassthrough", is_input=True, is_audio=True):
         for connected_port in jclient.get_all_connections(input_port):
-            jclient.disconnect(connected_port, input_port)
+            try:
+                jclient.disconnect(connected_port, input_port)
+            except Exception as e:
+                logging.exception(e)
     for output_port in jclient.get_ports("SynthPassthrough", is_output=True, is_audio=True):
         for connected_port in jclient.get_all_connections(output_port):
-            jclient.disconnect(output_port, connected_port)
+            try:
+                jclient.disconnect(output_port, connected_port)
+            except Exception as e:
+                logging.exception(e)
     ### END Disconnect all ports of SynthPassthrough
 
     ### BEGIN Connect the synth layer leafs up to the channel passthrough clients

--- a/zynautoconnect/zynthian_autoconnect.py
+++ b/zynautoconnect/zynthian_autoconnect.py
@@ -861,6 +861,10 @@ def audio_autoconnect(force=False):
                 # We have reached last client in output. Connect this client to both GlobalPlayback as well as AudioLevel
                 out_ports = jclient.get_ports(client_name, is_audio=True, is_output=True)
 
+                if len(out_ports) == 1:
+                    # If output is mono, connect both input to same output.
+                    out_ports = [out_ports[0], out_ports[0]]
+
                 for ports in zip(out_ports, channelAudioLevelsInputPorts):
                     logging.info(f"Connecting {ports[0]} to Audio levels {ports[1]}")
                     try:
@@ -875,6 +879,14 @@ def audio_autoconnect(force=False):
                 # Connect this client to the next client in list
                 out_ports = jclient.get_ports(client_name, is_audio=True, is_output=True)
                 in_ports = jclient.get_ports(output_client_names[index+1], is_audio=True, is_input=True)
+
+                if len(in_ports) == 1:
+                    # If input is mono, connect both output to same input.
+                    in_ports = [in_ports[0], in_ports[0]]
+
+                if len(out_ports) == 1:
+                    # If output is mono, connect both input to same output.
+                    out_ports = [out_ports[0], out_ports[0]]
 
                 for ports in zip(out_ports, in_ports):
                     logging.info(f"Connecting {ports[0]} to {ports[1]}")

--- a/zyngine/zynthian_layer.py
+++ b/zyngine/zynthian_layer.py
@@ -38,10 +38,11 @@ class zynthian_layer:
     # ---------------------------------------------------------------------------
 
 
-    def __init__(self, engine, midi_chan, zynqtgui=None):
+    def __init__(self, engine, midi_chan, zynqtgui=None, slot_index=-1):
         self.zynqtgui = zynqtgui
         self.engine = engine
         self.midi_chan = midi_chan
+        self.slot_index = slot_index
 
         self.jackname = None
         self.audio_out = ["system:playback_1", "system:playback_2"]
@@ -482,6 +483,7 @@ class zynthian_layer:
             'engine_nick': self.engine.nickname,
             'engine_type': self.engine.type,
             'midi_chan': self.midi_chan,
+            'slot_index': self.slot_index,
             'bank_index': self.bank_index,
             'bank_name': self.bank_name,
             'bank_info': self.bank_info,

--- a/zynqtgui/sketchpad/sketchpad_channel.py
+++ b/zynqtgui/sketchpad/sketchpad_channel.py
@@ -68,6 +68,7 @@ class sketchpad_channel(QObject):
         self.__connected_pattern__ = -1
         # self.__connected_sound__ = -1
         self.__chained_sounds__ = [-1, -1, -1, -1, -1]
+        self.__chained_fx = [None, None, None, None, None]
         self.zynqtgui.screens["layer"].layer_deleted.connect(self.layer_deleted)
         self.__muted__ = False
         self.__samples__ = []
@@ -907,6 +908,78 @@ class sketchpad_channel(QObject):
     chained_sounds_changed = Signal()
     chainedSounds = Property('QVariantList', get_chained_sounds, set_chained_sounds, notify=chained_sounds_changed)
     ### END Property chainedSounds
+
+    ### Property chainedFx
+    def get_chainedFx(self):
+        return self.__chained_fx
+
+    def set_chainedFx(self, fx):
+        if fx != self.__chained_fx:
+            self.__chained_fx = fx
+            self.update_jack_port()
+            self.update_sound_snapshot_json()
+            self.__song__.schedule_save()
+            self.chainedFxChanged.emit()
+
+    # Add or replace a fx layer at slot_row to fx chain
+    # If explicit slot_row is not set then selected slot row is used
+    def setFxToChain(self, layer, slot_row = None):
+        if slot_row is None:
+            slot_row = self.__selected_fx_slot_row
+
+        old_layer = self.__chained_fx[slot_row]
+
+        if old_layer is not None:
+            # Since there is already a layer in slot, replace existing layer with new one
+            try:
+                old_layer_index = self.zynqtgui.layer.layers.index(old_layer)
+                self.zynqtgui.layer.layers[old_layer_index] = layer
+            except:
+                pass
+
+            self.zynqtgui.zynautoconnect_acquire_lock()
+            old_layer.reset()
+            self.zynqtgui.zynautoconnect_release_lock()
+            self.zynqtgui.screens['engine'].stop_unused_engines()
+        else:
+            # Since there are no layer in slot, add layer to layer list
+            if layer not in self.zynqtgui.layer.layers:
+                self.zynqtgui.layer.layers.append(layer)
+
+        self.__chained_fx[slot_row] = layer
+        self.chainedFxChanged.emit()
+
+    @Slot()
+    def removeSelectedFxFromChain(self):
+        if self.__chained_fx[self.__selected_fx_slot_row] is not None:
+            try:
+                layer_index = self.zynqtgui.layer.layers.index(self.__chained_fx[self.__selected_fx_slot_row])
+                self.zynqtgui.layer.remove_layer(layer_index)
+                self.__chained_fx[self.__selected_fx_slot_row] = None
+
+                self.chainedFxChanged.emit()
+    #            self.zynqtgui.layer_effects.fx_layers_changed.emit()
+    #            self.zynqtgui.layer_effects.fx_layer = None
+    #            self.zynqtgui.layer_effects.fill_list()
+    #            self.zynqtgui.main_layers_view.fill_list()
+    #            self.zynqtgui.fixed_layers.fill_list()
+            except Exception as e:
+                logging.exception(e)
+
+    chainedFxChanged = Signal()
+    chainedFx = Property('QVariantList', get_chainedFx, set_chainedFx, notify=chainedFxChanged)
+    ### END Property chainedFx
+
+    ### Property chainedFxNames
+    def get_chainedFxNames(self):
+        return [self.__chained_fx[0].engine.name if self.__chained_fx[0] is not None else "",
+                self.__chained_fx[1].engine.name if self.__chained_fx[1] is not None else "",
+                self.__chained_fx[2].engine.name if self.__chained_fx[2] is not None else "",
+                self.__chained_fx[3].engine.name if self.__chained_fx[3] is not None else "",
+                self.__chained_fx[4].engine.name if self.__chained_fx[4] is not None else ""]
+
+    chainedFxNames = Property('QStringList', get_chainedFxNames, notify=chainedFxChanged)
+    ### END Property chainedFxNames
 
     ### Property connectedSound
     def get_connected_sound(self):

--- a/zynqtgui/sketchpad/sketchpad_channel.py
+++ b/zynqtgui/sketchpad/sketchpad_channel.py
@@ -924,6 +924,7 @@ class sketchpad_channel(QObject):
     # Add or replace a fx layer at slot_row to fx chain
     # If explicit slot_row is not set then selected slot row is used
     def setFxToChain(self, layer, slot_row=-1):
+
         if slot_row is -1:
             slot_row = self.__selected_fx_slot_row
 
@@ -934,8 +935,8 @@ class sketchpad_channel(QObject):
             try:
                 old_layer_index = self.zynqtgui.layer.layers.index(old_layer)
                 self.zynqtgui.layer.layers[old_layer_index] = layer
-            except:
-                pass
+            except Exception as e:
+                logging.exception(e)
 
             self.zynqtgui.zynautoconnect_acquire_lock()
             old_layer.reset()

--- a/zynqtgui/zynthian_gui_layer.py
+++ b/zynqtgui/zynthian_gui_layer.py
@@ -591,13 +591,13 @@ class zynthian_gui_layer(zynthian_gui_selector):
             else:
                 # When creating zynthian_layer, if engine is an audio effect, stores the channel id instead of midi channel
                 channel = midich
+                slot_index = -1
                 if zyngine.type=="Audio Effect":
                     channel = self.zynqtgui.session_dashboard.selectedChannel
+                    slot_index = self.zynqtgui.sketchpad.song.channelsModel.getChannel(channel).selectedFxSlotRow
 
-                layer = zynthian_layer(zyngine, channel, self.zynqtgui)
-                logging.debug(f">>>> add_layer_midich 3: {layer}, {layer.engine.type}, {layer.engine.name}")
+                layer = zynthian_layer(zyngine, channel, self.zynqtgui, slot_index)
 
-            logging.debug(f">>>> add_layer_midich 4: {midich}, {position_in_channel}")
             self.add_midichannel_to_channel(midich, position_in_channel)
 
             # Try to connect Audio Effects ...
@@ -1430,8 +1430,12 @@ class zynthian_gui_layer(zynthian_gui_selector):
                         snapshot['amixer_layer'] = lss
                     del(snapshot['layers'][i])
                 else:
+                    slot_index = lss['slot_index'] if "slot_index" in lss else -1
                     engine=self.zynqtgui.screens['engine'].start_engine(lss['engine_nick'])
-                    self.layers.append(zynthian_layer(engine,lss['midi_chan'], self.zynqtgui))
+                    layer = zynthian_layer(engine,lss['midi_chan'], self.zynqtgui, slot_index)
+                    self.layers.append(layer)
+                    if engine.type == "Audio Effect":
+                        self.zynqtgui.sketchpad.song.channelsModel.getChannel(layer.midi_chan).setFxToChain(layer, slot_index)
                 i += 1
 
             # Finally, stop all unused engines

--- a/zynqtgui/zynthian_gui_layer.py
+++ b/zynqtgui/zynthian_gui_layer.py
@@ -551,8 +551,8 @@ class zynthian_gui_layer(zynthian_gui_selector):
                             chain[i] = midich
                             break
             selected_channel.set_chained_sounds(chain)
-        except:
-            pass
+        except Exception as e:
+            logging.exception(e)
 
     def remove_midichannel_from_channel(self, midich):
         try:
@@ -562,14 +562,13 @@ class zynthian_gui_layer(zynthian_gui_selector):
                 if el == midich:
                     chain[i] = -1
             selected_channel.set_chained_sounds(chain)
-        except:
-            pass
+        except Exception as e:
+            logging.exception(e)
 
     def add_layer_midich(self, midich, select=True):
         if self.add_layer_eng:
             zyngine = self.zynqtgui.screens['engine'].start_engine(self.add_layer_eng)
             self.add_layer_eng = None
-
             position_in_channel = -1
             for i, element in enumerate(self.zynqtgui.screens['layers_for_channel'].list_data):
                 if midich == element[1]:
@@ -590,19 +589,21 @@ class zynthian_gui_layer(zynthian_gui_selector):
                 if not self.zynqtgui.screens['bank'].get_show_top_sounds():
                     self.zynqtgui.screens['bank'].select_action(0)
             else:
-                layer = zynthian_layer(zyngine, midich, self.zynqtgui)
+                # When creating zynthian_layer, if engine is an audio effect, stores the channel id instead of midi channel
+                channel = midich
+                if zyngine.type=="Audio Effect":
+                    channel = self.zynqtgui.session_dashboard.selectedChannel
 
+                layer = zynthian_layer(zyngine, channel, self.zynqtgui)
+                logging.debug(f">>>> add_layer_midich 3: {layer}, {layer.engine.type}, {layer.engine.name}")
+
+            logging.debug(f">>>> add_layer_midich 4: {midich}, {position_in_channel}")
             self.add_midichannel_to_channel(midich, position_in_channel)
 
             # Try to connect Audio Effects ...
             if len(self.layers)>0 and layer.engine.type=="Audio Effect":
-                if self.replace_layer_index is not None:
-                    self.replace_on_fxchain(layer)
-                else:
-                    self.add_to_fxchain(layer, self.layer_chain_parallel)
-                    if layer not in self.layers:
-                        self.layers.append(layer)
-                        self.layer_created.emit(midich)
+                # setFxToChain will handle adding layer to self.layers if a new fx is created or replace new layer with an old one
+                self.zynqtgui.sketchpad.song.channelsModel.getChannel(layer.midi_chan).setFxToChain(layer)
             # Try to connect MIDI tools ...
             elif len(self.layers)>0 and layer.engine.type=="MIDI Tool":
                 if self.replace_layer_index is not None:
@@ -650,7 +651,6 @@ class zynthian_gui_layer(zynthian_gui_selector):
                 self.drop_from_midichain(self.layers[i])
                 self.layers[i].mute_midi_out()
             else:
-                self.drop_from_fxchain(self.layers[i])
                 self.layers[i].mute_audio_out()
 
             self.layers[i].reset()
@@ -709,7 +709,6 @@ class zynthian_gui_layer(zynthian_gui_selector):
                 layers_to_delete += fxchain_layers
                 for layer in reversed(fxchain_layers):
                     logging.debug("Mute Audio layer '{}' ...".format(i, layer.get_basepath()))
-                    self.drop_from_fxchain(layer)
                     layer.mute_audio_out()
                 # Root_layer
                 layers_to_delete.append(root_layer)
@@ -761,7 +760,6 @@ class zynthian_gui_layer(zynthian_gui_selector):
             logging.debug("Mute layer {} => {} ...".format(i, self.layers[i].get_basepath()))
             self.drop_from_midichain(self.layers[i])
             self.layers[i].mute_midi_out()
-            self.drop_from_fxchain(self.layers[i])
             self.layers[i].mute_audio_out()
 
 
@@ -1091,94 +1089,6 @@ class zynthian_gui_layer(zynthian_gui_selector):
                 pars.append(l)
                 #logging.error("PARALLEL LAYER => {}".format(l.get_audio_jackname()))
         return pars
-
-
-    def add_to_fxchain(self, layer, chain_parallel=False):
-        try:
-            for end in self.get_fxchain_ends(layer):
-                if end!=layer:
-                    logging.debug("Adding to FX-chain {} => {}".format(end.get_audio_jackname(), layer.get_audio_jackname()))
-                    layer.set_audio_out(end.get_audio_out())
-                    if chain_parallel:
-                        for uslayer in self.get_fxchain_upstream(end):
-                            uslayer.add_audio_out(layer.get_audio_jackname())
-                    else:
-                        end.set_audio_out([layer.get_audio_jackname()])
-
-        except Exception as e:
-            logging.error("Error chaining Audio Effect ({})".format(e))
-
-
-    def replace_on_fxchain(self, layer):
-        try:
-            rlayer = self.layers[self.replace_layer_index]
-            logging.debug("Replacing on FX-chain {} => {}".format(rlayer.get_jackname(), layer.get_jackname()))
-            
-            # Re-route audio
-            layer.set_audio_out(rlayer.get_audio_out())
-            rlayer.mute_audio_out()
-            for uslayer in self.get_fxchain_upstream(rlayer):
-                uslayer.del_audio_out(rlayer.get_jackname())
-                uslayer.add_audio_out(layer.get_jackname())
-
-            # Replace layer in list
-            self.layers[self.replace_layer_index] = layer
-
-            # Remove old layer and stop unused engines
-            self.zynqtgui.zynautoconnect_acquire_lock()
-            rlayer.reset()
-            self.zynqtgui.zynautoconnect_release_lock()
-            self.zynqtgui.screens['engine'].stop_unused_engines()
-
-            self.replace_layer_index = None
-
-        except Exception as e:
-            logging.error("Error replacing Audio Effect ({})".format(e))
-
-
-    def drop_from_fxchain(self, layer):
-        try:
-            for up in self.get_fxchain_upstream(layer):
-                logging.debug("Dropping from FX-chain {} => {}".format(up.get_jackname(), layer.get_jackname()))
-                up.del_audio_out(layer.get_jackname())
-                if len(up.get_audio_out())==0:
-                    up.set_audio_out(layer.get_audio_out())
-
-        except Exception as e:
-            logging.error("Error unchaining Audio Effect ({})".format(e))
-
-
-    def swap_fxchain(self, layer1, layer2):
-        ups1 = self.get_fxchain_upstream(layer1)
-        ups2 = self.get_fxchain_upstream(layer2)
-
-        self.zynqtgui.zynautoconnect_acquire_lock()
-
-        # Move inputs from layer1 to layer2
-        for l in ups1:
-            l.add_audio_out(layer2.get_jackname())
-            l.del_audio_out(layer1.get_jackname())
-
-        # Move inputs from layer2 to layer1
-        for l in ups2:
-            l.add_audio_out(layer1.get_jackname())
-            l.del_audio_out(layer2.get_jackname())
-
-        # Swap outputs from layer1 & layer2
-        ao1 = layer1.audio_out
-        ao2 = layer2.audio_out
-        layer1.set_audio_out(ao2)
-        layer2.set_audio_out(ao1)
-
-        self.zynqtgui.zynautoconnect_release_lock()
-
-        # Swap position in layer list
-        for i,layer in enumerate(self.layers):
-            if layer==layer1:
-                self.layers[i] = layer2
-
-            elif layer==layer2:
-                self.layers[i] = layer1
 
     # ---------------------------------------------------------------------------
     # MIDI-Chain

--- a/zynqtgui/zynthian_gui_layer_effect_chooser.py
+++ b/zynqtgui/zynthian_gui_layer_effect_chooser.py
@@ -82,26 +82,26 @@ class zynthian_gui_layer_effect_chooser(zynthian_gui_engine):
         if i is not None and i >= 0 and i < len(self.list_data) and self.list_data[i][0]:
             try: #FIXME: why needed
                 self.zynqtgui.start_loading()
-                if self.zynqtgui.screens[self.effects_screen].fx_layer != None and self.zynqtgui.screens[self.effects_screen].fx_layer in self.zynqtgui.screens['layer'].layers:
-                    self.zynqtgui.screens['layer'].replace_layer_index = self.zynqtgui.screens['layer'].layers.index(self.zynqtgui.screens[self.effects_screen].fx_layer)
+#                if self.zynqtgui.screens[self.effects_screen].fx_layer != None and self.zynqtgui.screens[self.effects_screen].fx_layer in self.zynqtgui.screens['layer'].layers:
+#                    self.zynqtgui.screens['layer'].replace_layer_index = self.zynqtgui.screens['layer'].layers.index(self.zynqtgui.screens[self.effects_screen].fx_layer)
 
-                else:
-                    self.zynqtgui.screens['layer'].replace_layer_index = None
-                logging.debug(self.layer_chain_parallel)
+#                else:
+#                    self.zynqtgui.screens['layer'].replace_layer_index = None
+#                logging.debug(self.layer_chain_parallel)
                 self.zynqtgui.screens['layer'].layer_chain_parallel = self.layer_chain_parallel
                 #sometimes this raises an invalid index exection, despite the indexes having been checked already
                 self.zynqtgui.screens['layer'].add_layer_engine(self.list_data[i][0], self.zynqtgui.curlayer.midi_chan, False)
 
-                self.zynqtgui.screens[self.effects_screen].show()
+#                self.zynqtgui.screens[self.effects_screen].show()
 
-                if self.zynqtgui.screens['layer'].replace_layer_index is None:
-                    self.zynqtgui.screens[self.effects_screen].select_action(len(self.zynqtgui.screens[self.effects_screen].fx_layers) - 1)
-                else:
-                    self.zynqtgui.screens[self.effects_screen].select_action(self.zynqtgui.screens['layer'].replace_layer_index)
+#                if self.zynqtgui.screens['layer'].replace_layer_index is None:
+#                    self.zynqtgui.screens[self.effects_screen].select_action(len(self.zynqtgui.screens[self.effects_screen].fx_layers) - 1)
+#                else:
+#                    self.zynqtgui.screens[self.effects_screen].select_action(self.zynqtgui.screens['layer'].replace_layer_index)
 
-                self.zynqtgui.screens['layer'].replace_layer_index = None
+#                self.zynqtgui.screens['layer'].replace_layer_index = None
 
-                self.zynqtgui.screens['main_layers_view'].fill_list()
+#                self.zynqtgui.screens['main_layers_view'].fill_list()
                 self.zynqtgui.stop_loading()
                 if self.midi_mode:
                     self.zynqtgui.show_screen("layer_midi_effect_chooser")
@@ -110,8 +110,8 @@ class zynthian_gui_layer_effect_chooser(zynthian_gui_engine):
 
                 self.zynqtgui.screens["fixed_layers"].fill_list()
                 self.zynqtgui.screens['snapshot'].save_last_state_snapshot()
-            except:
-                pass
+            except Exception as e:
+                logging.exception(e)
 
 
     def back_action(self):


### PR DESCRIPTION
Zynthian's implementation of FX was based on the midi channel. Every synth was assigned a midi channel and a series of FX can be assigned per synth in serial or parallel mode.

With Zynthbox, we have the concept of tracks. There are 10 tracks and each track have 5 slots for synths. The synths are always chained in a track. So any FX in a track should also be chained for all the synths in the track.

Hence update old fx logic to now use the new Channel passthrough clients to connect so that the jack graph looks like :

Synth -> Synth passthrough -> Channel Passthrough -> &lt;All assigned FX connected in series if any&gt; -> Global Playback

SamplerSynth then connects to Channel passthrough eventually getting connected to GlobalPlayback via the assigned FX in that channel