### PR TITLE
Tweaks to the status info bar

### DIFF
--- a/qml-ui/Zynthian/StatusInfo.qml
+++ b/qml-ui/Zynthian/StatusInfo.qml
@@ -67,6 +67,8 @@ QQC2.Pane
                 Layout.fillWidth: true
 
                 Item {
+                    id: bar1
+
                     Layout.fillWidth: true
                     implicitHeight: 6
                     clip: true
@@ -77,7 +79,6 @@ QQC2.Pane
                         opacity: 0.2
                         radius: 3
                     }
-
                     Rectangle {
                         id: holdSignalARect
                         anchors {
@@ -85,7 +86,7 @@ QQC2.Pane
                             bottom: parent.bottom
                         }
                         radius: 3
-                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackAHold / zynqtgui.status_information.rangedB), 1) * root.width)
+                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackAHold / zynqtgui.status_information.rangedB), 1) * bar1.width)
                         opacity: x === 0 ? 0 : 1
                         implicitWidth: Kirigami.Units.smallSpacing
                         color: Kirigami.Theme.negativeTextColor
@@ -111,7 +112,7 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.negativeTextColor
-                        width: highSignalARect.peakSignalA * root.width
+                        width: highSignalARect.peakSignalA * bar1.width
                         property double peakSignalA: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackA / zynqtgui.status_information.rangedB), 1)
                     }
                     Rectangle {
@@ -123,7 +124,7 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.neutralTextColor
-                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.over) * root.width
+                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.over) * bar1.width
                     }
                     Rectangle {
                         id: lowSignalARect
@@ -134,11 +135,13 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.positiveTextColor
-                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.high) * root.width
+                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.high) * bar1.width
                     }
                 }
 
                 Item {
+                    id: bar2
+
                     Layout.fillWidth: true
                     implicitHeight: 6
                     clip: true
@@ -157,7 +160,7 @@ QQC2.Pane
                             bottom: parent.bottom
                         }
                         radius: 3
-                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackBHold / zynqtgui.status_information.rangedB), 1) * root.width)
+                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackBHold / zynqtgui.status_information.rangedB), 1) * bar2.width)
                         opacity: x === 0 ? 0 : 1
                         implicitWidth: Kirigami.Units.smallSpacing
                         color: Kirigami.Theme.negativeTextColor
@@ -183,7 +186,7 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.negativeTextColor
-                        width: Math.min(highSignalBRect.peakSignalB, 1) * root.width
+                        width: Math.min(highSignalBRect.peakSignalB, 1) * bar2.width
                         property double peakSignalB: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackB / zynqtgui.status_information.rangedB), 1)
                     }
                     Rectangle {
@@ -195,7 +198,7 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.neutralTextColor
-                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.over) * root.width
+                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.over) * bar2.width
                     }
                     Rectangle {
                         id: lowSignalBRect
@@ -206,7 +209,7 @@ QQC2.Pane
                         }
                         radius: 3
                         color: Kirigami.Theme.positiveTextColor
-                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.high) * root.width
+                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.high) * bar2.width
                     }
                 }
 

--- a/qml-ui/Zynthian/StatusInfo.qml
+++ b/qml-ui/Zynthian/StatusInfo.qml
@@ -32,292 +32,327 @@ import io.zynthbox.components 1.0 as Zynthbox
 import Zynthian 1.0 as Zynthian
 import "private" as Private
 
-MouseArea {
+QQC2.Pane
+{
     id: root
-    Layout.minimumWidth: Kirigami.Units.gridUnit * 10
-    Layout.maximumWidth: Kirigami.Units.gridUnit * 10
+
+    property bool highlighted : false
+
+    Layout.minimumWidth: Kirigami.Units.gridUnit * 12
+    Layout.maximumWidth: Kirigami.Units.gridUnit * 12
+
     Layout.fillHeight: true
 
-    onClicked: zynqtgui.globalPopupOpened = true
+    Layout.margins: Kirigami.Units.smallSpacing
+    padding: Kirigami.Units.mediumSpacing
 
-    ColumnLayout {
-        anchors {
-            left: parent.left
-            top: parent.top
-            right: parent.right
-        }
-        height: parent.height / 2
-        Item {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-
-            Rectangle {
-                id: holdSignalARect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                }
-                radius: 3
-                x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackAHold / zynqtgui.status_information.rangedB), 1) * root.width)
-                opacity: x === 0 ? 0 : 1
-                implicitWidth: Kirigami.Units.smallSpacing
-                color: Kirigami.Theme.negativeTextColor
-                Behavior on x {
-                    XAnimator {
-                        duration: Kirigami.Units.shortDuration
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-                Behavior on opacity {
-                    OpacityAnimator {
-                        duration: Kirigami.Units.longDuration
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-            }
-            Rectangle {
-                id: highSignalARect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.negativeTextColor
-                width: highSignalARect.peakSignalA * root.width
-                property double peakSignalA: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackA / zynqtgui.status_information.rangedB), 1)
-            }
-            Rectangle {
-                id: mediumSignalARect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.neutralTextColor
-                width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.over) * root.width
-            }
-            Rectangle {
-                id: lowSignalARect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.positiveTextColor
-                width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.high) * root.width
-            }
-        }
-
-        Item {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-
-            Rectangle {
-                id: holdSignalBRect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                }
-                radius: 3
-                x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackBHold / zynqtgui.status_information.rangedB), 1) * root.width)
-                opacity: x === 0 ? 0 : 1
-                implicitWidth: Kirigami.Units.smallSpacing
-                color: Kirigami.Theme.negativeTextColor
-                Behavior on x {
-                    XAnimator {
-                        duration: Kirigami.Units.shortDuration
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-                Behavior on opacity {
-                    OpacityAnimator {
-                        duration: Kirigami.Units.longDuration
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-            }
-            Rectangle {
-                id: highSignalBRect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.negativeTextColor
-                width: Math.min(highSignalBRect.peakSignalB, 1) * root.width
-                property double peakSignalB: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackB / zynqtgui.status_information.rangedB), 1)
-            }
-            Rectangle {
-                id: mediumSignalBRect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.neutralTextColor
-                width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.over) * root.width
-            }
-            Rectangle {
-                id: lowSignalBRect
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                    left: parent.left
-                }
-                radius: 3
-                color: Kirigami.Theme.positiveTextColor
-                width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.high) * root.width
-            }
-        }
+    background: Rectangle
+    {
+        Kirigami.Theme.colorSet: Kirigami.Theme.Button
+        Kirigami.Theme.inherit: false
+        color: Kirigami.Theme.alternateBackgroundColor
+        radius: 4
+        border.color: root.highlighted ? Kirigami.Theme.highlightColor : Qt.darker(Kirigami.Theme.alternateBackgroundColor, 1.5)
     }
 
-    RowLayout {
-        id: statusIconsLayout
-        anchors {
-            right: parent.right
-            bottom: parent.bottom
-        }
-        height: Math.min(parent.height / 2, Kirigami.Units.iconSizes.smallMedium)
-        QQC2.Label {
-            Layout.fillHeight: true
-            Layout.margins: statusIconsLayout.height / 4
-            color: Kirigami.Theme.textColor
-            font.pixelSize: Math.floor(statusIconsLayout.height / 2)
-            text: "ALT"
-            visible: zynqtgui.altButtonPressed
-            Rectangle {
-                anchors {
-                    fill: parent
-                    margins: -2
+    contentItem: MouseArea {
+
+        onClicked: zynqtgui.globalPopupOpened = true
+
+        RowLayout {
+            anchors.fill: parent
+            spacing: Kirigami.Units.mediumSpacing
+
+            ColumnLayout {
+                Layout.fillWidth: true
+
+                Item {
+                    Layout.fillWidth: true
+                    implicitHeight: 6
+                    clip: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: Kirigami.Theme.textColor
+                        opacity: 0.2
+                        radius: 3
+                    }
+
+                    Rectangle {
+                        id: holdSignalARect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                        }
+                        radius: 3
+                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackAHold / zynqtgui.status_information.rangedB), 1) * root.width)
+                        opacity: x === 0 ? 0 : 1
+                        implicitWidth: Kirigami.Units.smallSpacing
+                        color: Kirigami.Theme.negativeTextColor
+                        Behavior on x {
+                            XAnimator {
+                                duration: Kirigami.Units.shortDuration
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                        Behavior on opacity {
+                            OpacityAnimator {
+                                duration: Kirigami.Units.longDuration
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                    }
+                    Rectangle {
+                        id: highSignalARect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.negativeTextColor
+                        width: highSignalARect.peakSignalA * root.width
+                        property double peakSignalA: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackA / zynqtgui.status_information.rangedB), 1)
+                    }
+                    Rectangle {
+                        id: mediumSignalARect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.neutralTextColor
+                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.over) * root.width
+                    }
+                    Rectangle {
+                        id: lowSignalARect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.positiveTextColor
+                        width: Math.min(highSignalARect.peakSignalA, zynqtgui.status_information.high) * root.width
+                    }
                 }
-                color: "transparent"
-                border {
-                    width: 1
+
+                Item {
+                    Layout.fillWidth: true
+                    implicitHeight: 6
+                    clip: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: Kirigami.Theme.textColor
+                        opacity: 0.2
+                        radius: 3
+                    }
+
+                    Rectangle {
+                        id: holdSignalBRect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                        }
+                        radius: 3
+                        x: Math.floor(Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackBHold / zynqtgui.status_information.rangedB), 1) * root.width)
+                        opacity: x === 0 ? 0 : 1
+                        implicitWidth: Kirigami.Units.smallSpacing
+                        color: Kirigami.Theme.negativeTextColor
+                        Behavior on x {
+                            XAnimator {
+                                duration: Kirigami.Units.shortDuration
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                        Behavior on opacity {
+                            OpacityAnimator {
+                                duration: Kirigami.Units.longDuration
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                    }
+                    Rectangle {
+                        id: highSignalBRect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.negativeTextColor
+                        width: Math.min(highSignalBRect.peakSignalB, 1) * root.width
+                        property double peakSignalB: Math.min(Math.max(0, 1 + Zynthbox.AudioLevels.playbackB / zynqtgui.status_information.rangedB), 1)
+                    }
+                    Rectangle {
+                        id: mediumSignalBRect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.neutralTextColor
+                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.over) * root.width
+                    }
+                    Rectangle {
+                        id: lowSignalBRect
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        radius: 3
+                        color: Kirigami.Theme.positiveTextColor
+                        width: Math.min(highSignalBRect.peakSignalB, zynqtgui.status_information.high) * root.width
+                    }
+                }
+
+                RowLayout {
+                    id: statusIconsLayout
+                    Layout.fillWidth: true
+
+                    QQC2.Label {
+                        color: Kirigami.Theme.textColor
+                        font.pointSize: 7
+                        text: "ALT"
+                        padding: 1
+                        visible: zynqtgui.altButtonPressed
+                        background: Rectangle {
+                            color: "transparent"
+                            border {
+                                width: 1
+                                color: Kirigami.Theme.textColor
+                            }
+                            radius: 3
+                        }
+                    }
+                    Kirigami.Icon {
+                        implicitHeight: 16
+                        implicitWidth: 16
+                        source: "dialog-warning-symbolic"
+                        color: Kirigami.Theme.negativeTextColor
+                        visible: zynqtgui.status_information.xrun
+                    }
+                    Kirigami.Icon {
+                        implicitHeight: 16
+                        implicitWidth: 16
+                        source: "preferences-system-power"
+                        visible: zynqtgui.status_information.undervoltage
+                    }
+                    Kirigami.Icon {
+                        id: audioRecorderIcon
+                        implicitHeight: 16
+                        implicitWidth: 16
+                        color: Kirigami.Theme.textColor
+                        source: "media-playback-start-symbolic";
+                        function updateIcon() {
+                            if (audioRecorderIcon.visible) {
+                                switch(zynqtgui.status_information.audio_recorder) {
+                                case "PLAY":
+                                    if (audioRecorderIcon.source !== "media-playback-start-symbolic") {
+                                        audioRecorderIcon.source = "media-playback-start-symbolic";
+                                    }
+                                    break;
+                                case "REC":
+                                default:
+                                    if (audioRecorderIcon.source !== "media-record-symbolic") {
+                                        audioRecorderIcon.source = "media-record-symbolic";
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                        Connections {
+                            target: zynqtgui.status_information
+                            onAudio_recorderChanged: audioRecorderIcon.updateIcon();
+                        }
+                        onVisibleChanged: audioRecorderIcon.updateIcon();
+                        QQC2.Label {
+                            anchors {
+                                right: parent.right
+                                bottom: parent.bottom
+                            }
+                            font.pointSize: 6
+                            text: qsTr("Audio")
+                            color: Kirigami.Theme.neutralTextColor
+                        }
+                        visible: zynqtgui.status_information.audio_recorder.length > 0
+                    }
+                    QQC2.Label {
+                        visible: Zynthbox.PlayGridManager.hardwareInActiveNotes.length > 0
+                        text: visible
+                              ? "<font size=\"1\">I:</font>" + Zynthbox.PlayGridManager.hardwareInActiveNotes[0] + (Zynthbox.PlayGridManager.hardwareInActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.hardwareInActiveNotes.length - 1) : "")
+                              : ""
+                        font.pointSize: 9
+                    }
+                    QQC2.Label {
+                        Layout.alignment: Qt.AlignRight
+                        visible: Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length > 0
+                        text: visible
+                              ? Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes[0] + (Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length - 1) : "")
+                              : ""
+                        font.pointSize: 9
+                    }
+                    QQC2.Label {
+                        Layout.alignment: Qt.AlignRight
+                        visible: Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length > 0
+                        text: visible
+                              ? "<font size=\"1\">S:</font>" + Zynthbox.PlayGridManager.internalPassthroughActiveNotes[0] + (Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length - 1) : "")
+                              : ""
+                        font.pointSize: 9
+                    }
+                    //        QQC2.Label {
+                    //            visible: Zynthbox.PlayGridManager.hardwareOutActiveNotes.length > 0
+                    //            text: visible
+                    //                ? "<font size=\"1\">O:</font>" + Zynthbox.PlayGridManager.hardwareOutActiveNotes[0] + (Zynthbox.PlayGridManager.hardwareOutActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.hardwareOutActiveNotes.length - 1) : "")
+                    //                : ""
+                    //            font.pointSize: 9
+                    //        }
+                    QQC2.Label {
+                        Layout.alignment: Qt.AlignRight
+                        id: metronomeLabel
+                        font.pointSize: 9
+                        text: {
+                            if (zynqtgui.sketchpad.isMetronomeRunning && zynqtgui.sketchpad.currentBeat >= 0 && zynqtgui.sketchpad.currentBar >= 0) {
+                                return (zynqtgui.sketchpad.currentBar+1) + "." + (zynqtgui.sketchpad.currentBeat+1)
+                            } else {
+                                return "1.1"
+                            }
+                        }
+                    }
+                }
+            }
+
+            ColumnLayout {
+               Layout.fillHeight: true
+                QQC2.Label {
+                    id: bpmLabel
+                    // Hide scale info for now
+                    // text: zynqtgui.sketchpad.song.selectedScale +" "+ Zynthbox.SyncTimer.bpm
+                    text: Zynthbox.SyncTimer.bpm
+                    font.pointSize: 9
+                }
+                Kirigami.Icon {
+                    Layout.alignment: Qt.AlignCenter
+                    implicitHeight: 16
+                    implicitWidth: 16
+                    source: Qt.resolvedUrl("../../img/metronome.svg")
                     color: Kirigami.Theme.textColor
-                }
-                radius: 3
-            }
-        }
-        Kirigami.Icon {
-            Layout.fillHeight: true
-            Layout.preferredWidth: height
-            source: "dialog-warning-symbolic"
-            color: Kirigami.Theme.negativeTextColor
-            visible: zynqtgui.status_information.xrun
-        }
-        Kirigami.Icon {
-            Layout.fillHeight: true
-            Layout.preferredWidth: height
-            source: "preferences-system-power"
-            visible: zynqtgui.status_information.undervoltage
-        }
-        Kirigami.Icon {
-            id: audioRecorderIcon
-            Layout.fillHeight: true
-            Layout.preferredWidth: height
-            color: Kirigami.Theme.textColor
-            source: "media-playback-start-symbolic";
-            function updateIcon() {
-                if (audioRecorderIcon.visible) {
-                    switch(zynqtgui.status_information.audio_recorder) {
-                    case "PLAY":
-                        if (audioRecorderIcon.source !== "media-playback-start-symbolic") {
-                            audioRecorderIcon.source = "media-playback-start-symbolic";
-                        }
-                        break;
-                    case "REC":
-                    default:
-                        if (audioRecorderIcon.source !== "media-record-symbolic") {
-                            audioRecorderIcon.source = "media-record-symbolic";
-                        }
-                        break;
-                    }
+                    opacity: zynqtgui.sketchpad.metronomeEnabled ? 1.0 : 0.0
                 }
             }
-            Connections {
-                target: zynqtgui.status_information
-                onAudio_recorderChanged: audioRecorderIcon.updateIcon();
-            }
-            onVisibleChanged: audioRecorderIcon.updateIcon();
-            QQC2.Label {
-                anchors {
-                    right: parent.right
-                    bottom: parent.bottom
-                }
-                font.pointSize: 6
-                text: qsTr("Audio")
-            }
-            visible: zynqtgui.status_information.audio_recorder.length > 0
-        }
-        QQC2.Label {
-            visible: Zynthbox.PlayGridManager.hardwareInActiveNotes.length > 0
-            text: visible
-                ? "<font size=\"1\">I:</font>" + Zynthbox.PlayGridManager.hardwareInActiveNotes[0] + (Zynthbox.PlayGridManager.hardwareInActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.hardwareInActiveNotes.length - 1) : "")
-                : ""
-            font.pointSize: 9
-        }
-        QQC2.Label {
-            visible: Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length > 0
-            text: visible
-                ? Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes[0] + (Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.internalControllerPassthroughActiveNotes.length - 1) : "")
-                : ""
-            font.pointSize: 9
-        }
-        QQC2.Label {
-            visible: Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length > 0
-            text: visible
-                ? "<font size=\"1\">S:</font>" + Zynthbox.PlayGridManager.internalPassthroughActiveNotes[0] + (Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.internalPassthroughActiveNotes.length - 1) : "")
-                : ""
-            font.pointSize: 9
-        }
-//        QQC2.Label {
-//            visible: Zynthbox.PlayGridManager.hardwareOutActiveNotes.length > 0
-//            text: visible
-//                ? "<font size=\"1\">O:</font>" + Zynthbox.PlayGridManager.hardwareOutActiveNotes[0] + (Zynthbox.PlayGridManager.hardwareOutActiveNotes.length > 1 ? "+" + (Zynthbox.PlayGridManager.hardwareOutActiveNotes.length - 1) : "")
-//                : ""
-//            font.pointSize: 9
-//        }
-        QQC2.Label {
-            id: metronomeLabel
-            text: {
-                if (zynqtgui.sketchpad.isMetronomeRunning && zynqtgui.sketchpad.currentBeat >= 0 && zynqtgui.sketchpad.currentBar >= 0) {
-                    return (zynqtgui.sketchpad.currentBar+1) + "." + (zynqtgui.sketchpad.currentBeat+1)
-                } else {
-                    return "1.1"
-                }
-            }
-        }
-        ColumnLayout {
-            Layout.alignment: Qt.AlignBottom
-            Layout.topMargin: parent.height  -height
-            QQC2.Label {
-                id: bpmLabel
-                // Hide scale info for now
-                // text: zynqtgui.sketchpad.song.selectedScale +" "+ Zynthbox.SyncTimer.bpm
-                text: Zynthbox.SyncTimer.bpm
-                font.pointSize: 9
-            }
-            Kirigami.Icon {
-                Layout.preferredWidth: 24
-                Layout.preferredHeight: 24
-                source: Qt.resolvedUrl("../../img/metronome.svg")
-                color: "#ffffff"
-                opacity: zynqtgui.sketchpad.metronomeEnabled ? 1.0 : 0.0
-            }
-        }
-    }
 
-    Zynthian.Popup {
-        id: popup
+        }
 
-        property var cuiaCallback: function(cuia) {
-            var result = popup.opened;
-            switch(cuia) {
+        Zynthian.Popup {
+            id: popup
+
+            property var cuiaCallback: function(cuia) {
+                var result = popup.opened;
+                switch(cuia) {
                 case "SWITCH_PLAY":
                 case "SWITCH_STOP":
                 case "ALL_NOTES_OFF":
@@ -395,352 +430,353 @@ MouseArea {
                     }
                     result = true;
                     break;
+                }
+                return result;
             }
-            return result;
-        }
 
-        visible: zynqtgui.globalPopupOpened
-        y: parent.height
-        x: parent.width - width
-        width: Kirigami.Units.gridUnit * 24
-        height: Kirigami.Units.gridUnit * 28
-        onClosed: zynqtgui.globalPopupOpened = false
-        contentItem: Item {
-            GridLayout {
-                anchors.fill: parent;
-                columns: 3
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: Item {
-                        ColumnLayout {
-                            anchors.fill: parent
-                            SketchpadDial {
-                                Layout.fillHeight: true
-                                Layout.fillWidth: true
-                                Layout.margins: Kirigami.Units.gridUnit
-                                id: volumeDial
-                                text: qsTr("Volume")
-                                controlObj: zynqtgui
-                                controlProperty: "masterVolume"
-                                valueString: qsTr("%1%").arg(dial.value)
-                                knobId: 3
+            visible: zynqtgui.globalPopupOpened
+            y: parent.height
+            x: parent.width - width
+            width: Kirigami.Units.gridUnit * 24
+            height: Kirigami.Units.gridUnit * 28
+            onClosed: zynqtgui.globalPopupOpened = false
+            contentItem: Item {
+                GridLayout {
+                    anchors.fill: parent;
+                    columns: 3
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: Item {
+                            ColumnLayout {
+                                anchors.fill: parent
+                                SketchpadDial {
+                                    Layout.fillHeight: true
+                                    Layout.fillWidth: true
+                                    Layout.margins: Kirigami.Units.gridUnit
+                                    id: volumeDial
+                                    text: qsTr("Volume")
+                                    controlObj: zynqtgui
+                                    controlProperty: "masterVolume"
+                                    valueString: qsTr("%1%").arg(dial.value)
+                                    knobId: 3
 
-                                dial {
-                                    stepSize: 1
-                                    from: 0
-                                    to: 100
-                                }
-                            }
-                        }
-                    }
-                }
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: ColumnLayout {
-                        visible: false // Hide scale for now
-                        SketchpadMultiSwitch {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            controlObj: zynqtgui.sketchpad.song
-                            controlProperty: "selectedScaleIndex"
-                            from: 0
-                            to: 11
-                            text: zynqtgui.sketchpad.song.selectedScale
-                        }
-                        QQC2.Label {
-                            text: qsTr("Scale")
-                            Layout.fillWidth: true
-                            horizontalAlignment: Text.AlignHCenter
-                        }
-                    }
-                }
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: Item {
-                        ColumnLayout {
-                            anchors.fill: parent
-                            SketchpadDial {
-                                Layout.fillHeight: true
-                                Layout.fillWidth: true
-                                Layout.margins: Kirigami.Units.gridUnit
-                                id: bpmDial
-                                text: qsTr("BPM")
-                                controlObj: Zynthbox.SyncTimer
-                                controlProperty: "bpm"
-                                knobId: 0
-
-                                dial {
-                                    stepSize: 1
-                                    from: 50
-                                    to: 200
-                                }
-
-                                onPressed: registerTap();
-                                property int bpm: 0
-                                property var timestamps: []
-                                function registerTap() {
-                                    var newStamp = Date.now();
-                                    if (bpmDial.timestamps.length > 0 && newStamp - bpmDial.timestamps[timestamps.length - 1] > 2000) {
-                                        // If the most recent tap was more than two seconds ago, clear the list and start a new estimation
-                                        bpmDial.timestamps = [];
-                                        bpm = 0;
-                                    }
-                                    bpmDial.timestamps.push(newStamp);
-                                    if (bpmDial.timestamps.length > 1) {
-                                        var differences = [];
-                                        for (var i = 0; i < bpmDial.timestamps.length - 1; ++i) {
-                                            differences.push(bpmDial.timestamps[i + 1] - bpmDial.timestamps[i]);
-                                        }
-                                        var sum = 0;
-                                        for (var i = 0; i < differences.length; ++i) {
-                                            sum += differences[i];
-                                        }
-                                        var average = sum / differences.length;
-                                        bpmDial.bpm = 60000 / average;
-                                        Zynthbox.SyncTimer.setBpm(bpmDial.bpm)
+                                    dial {
+                                        stepSize: 1
+                                        from: 0
+                                        to: 100
                                     }
                                 }
                             }
                         }
                     }
-                }
-
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: Item {
-                        ColumnLayout {
-                            anchors.fill: parent
-                            SketchpadDial {
-                                Layout.fillHeight: true
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: ColumnLayout {
+                            visible: false // Hide scale for now
+                            SketchpadMultiSwitch {
                                 Layout.fillWidth: true
-                                Layout.margins: Kirigami.Units.gridUnit
-                                text: qsTr("Delay")
-                                controlObj: zynqtgui.delayController
-                                controlProperty: "value"
-                                valueString: qsTr("%1%").arg(dial.value)
-                                knobId: 1
-
-                                dial {
-                                    stepSize: zynqtgui.delayController.step_size
-                                    from: zynqtgui.delayController.value_min
-                                    to: zynqtgui.delayController.value_max
-                                }
-                                onClicked: {
-                                    zynqtgui.editGlobalFX(0);
-                                    popup.close();
-                                }
-                                // Apparently neither of our two global fx picks have presets defined, so... never mind showing the button
-                                // action: QQC2.Action {
-                                //     text: "Preset Name"
-                                //     onTriggered: {
-                                //         zynqtgui.selectGlobalFXPreset(0);
-                                //         popup.close();
-                                //     }
-                                // }
+                                Layout.fillHeight: true
+                                controlObj: zynqtgui.sketchpad.song
+                                controlProperty: "selectedScaleIndex"
+                                from: 0
+                                to: 11
+                                text: zynqtgui.sketchpad.song.selectedScale
+                            }
+                            QQC2.Label {
+                                text: qsTr("Scale")
+                                Layout.fillWidth: true
+                                horizontalAlignment: Text.AlignHCenter
                             }
                         }
                     }
-                }
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: ColumnLayout {
-                        visible: false // Hide BT for now
-                        Layout.alignment: Qt.AlignVCenter
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: Item {
+                            ColumnLayout {
+                                anchors.fill: parent
+                                SketchpadDial {
+                                    Layout.fillHeight: true
+                                    Layout.fillWidth: true
+                                    Layout.margins: Kirigami.Units.gridUnit
+                                    id: bpmDial
+                                    text: qsTr("BPM")
+                                    controlObj: Zynthbox.SyncTimer
+                                    controlProperty: "bpm"
+                                    knobId: 0
+
+                                    dial {
+                                        stepSize: 1
+                                        from: 50
+                                        to: 200
+                                    }
+
+                                    onPressed: registerTap();
+                                    property int bpm: 0
+                                    property var timestamps: []
+                                    function registerTap() {
+                                        var newStamp = Date.now();
+                                        if (bpmDial.timestamps.length > 0 && newStamp - bpmDial.timestamps[timestamps.length - 1] > 2000) {
+                                            // If the most recent tap was more than two seconds ago, clear the list and start a new estimation
+                                            bpmDial.timestamps = [];
+                                            bpm = 0;
+                                        }
+                                        bpmDial.timestamps.push(newStamp);
+                                        if (bpmDial.timestamps.length > 1) {
+                                            var differences = [];
+                                            for (var i = 0; i < bpmDial.timestamps.length - 1; ++i) {
+                                                differences.push(bpmDial.timestamps[i + 1] - bpmDial.timestamps[i]);
+                                            }
+                                            var sum = 0;
+                                            for (var i = 0; i < differences.length; ++i) {
+                                                sum += differences[i];
+                                            }
+                                            var average = sum / differences.length;
+                                            bpmDial.bpm = 60000 / average;
+                                            Zynthbox.SyncTimer.setBpm(bpmDial.bpm)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: Item {
+                            ColumnLayout {
+                                anchors.fill: parent
+                                SketchpadDial {
+                                    Layout.fillHeight: true
+                                    Layout.fillWidth: true
+                                    Layout.margins: Kirigami.Units.gridUnit
+                                    text: qsTr("Delay")
+                                    controlObj: zynqtgui.delayController
+                                    controlProperty: "value"
+                                    valueString: qsTr("%1%").arg(dial.value)
+                                    knobId: 1
+
+                                    dial {
+                                        stepSize: zynqtgui.delayController.step_size
+                                        from: zynqtgui.delayController.value_min
+                                        to: zynqtgui.delayController.value_max
+                                    }
+                                    onClicked: {
+                                        zynqtgui.editGlobalFX(0);
+                                        popup.close();
+                                    }
+                                    // Apparently neither of our two global fx picks have presets defined, so... never mind showing the button
+                                    // action: QQC2.Action {
+                                    //     text: "Preset Name"
+                                    //     onTriggered: {
+                                    //         zynqtgui.selectGlobalFXPreset(0);
+                                    //         popup.close();
+                                    //     }
+                                    // }
+                                }
+                            }
+                        }
+                    }
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: ColumnLayout {
+                            visible: false // Hide BT for now
+                            Layout.alignment: Qt.AlignVCenter
+                            QQC2.Label {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                                wrapMode: Text.Wrap
+                                text: bluetoothSetup.connectedDevice === null ? qsTr("Not\nConnected") : qsTr("Connected to\n%1").arg(bluetoothSetup.connectedDevice.name)
+                            }
+                            QQC2.Button {
+                                icon.name: bluetoothSetup.connectedDevice === null ? "network-bluetooth" : "network-bluetooth-activated"
+                                text: qsTr("Setup")
+                                display: QQC2.AbstractButton.TextBesideIcon
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.fillWidth: true
+                                onClicked: {
+                                    bluetoothSetup.show();
+                                }
+                            }
+                            QQC2.Label {
+                                Layout.fillWidth: true
+                                horizontalAlignment: Text.AlignHCenter
+                                text: qsTr("BT Audio")
+                            }
+                        }
+                    }
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit * 4
+                        contentItem: Item {
+                            ColumnLayout {
+                                anchors.fill: parent
+                                SketchpadDial {
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                    Layout.margins: Kirigami.Units.gridUnit
+                                    text: qsTr("Reverb")
+                                    controlObj: zynqtgui.reverbController
+                                    controlProperty: "value"
+                                    valueString: qsTr("%1%").arg(dial.value)
+                                    knobId: 2
+
+                                    dial {
+                                        stepSize: zynqtgui.reverbController.step_size
+                                        from: zynqtgui.reverbController.value_min
+                                        to: zynqtgui.reverbController.value_max
+                                    }
+                                    onClicked: {
+                                        zynqtgui.editGlobalFX(1);
+                                        popup.close();
+                                    }
+                                    // Apparently neither of our two global fx picks have presets defined, so... never mind showing the button
+                                    // action: QQC2.Action {
+                                    //     text: "Preset Name"
+                                    //     onTriggered: {
+                                    //         zynqtgui.selectGlobalFXPreset(1);
+                                    //         popup.close();
+                                    //     }
+                                    // }
+                                }
+                            }
+                        }
+                    }
+
+                    Card {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit
+                        Layout.columnSpan: 2
+                        contentItem: RowLayout {
+                            Layout.alignment: Qt.AlignLeft
+                            QQC2.Switch {
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+                                checked: zynqtgui.sketchpad.metronomeEnabled
+                                text: qsTr("Click")
+                                onToggled: {
+                                    zynqtgui.sketchpad.metronomeEnabled = checked
+                                }
+                            }
+                            QQC2.Slider {
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.preferredHeight: Kirigami.Units.gridUnit
+                                Layout.fillWidth: true
+                                enabled: zynqtgui.sketchpad.metronomeEnabled
+                                from: 0
+                                to: 1
+                                value: zynqtgui.sketchpad.metronomeVolume
+                                onValueChanged: zynqtgui.sketchpad.metronomeVolume = value
+                            }
+                            Item {
+                                Layout.fillWidth: true
+                            }
+                        }
+                    }
+                    QQC2.Button {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+                        Layout.preferredHeight: Kirigami.Units.gridUnit
+                        text: qsTr("Stop All Notes")
+                        onClicked: zynqtgui.callable_ui_action_simple("ALL_NOTES_OFF")
+                    }
+
+                    RowLayout {
+                        Layout.columnSpan: 3
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Kirigami.Units.largeSpacing
+                        Kirigami.Theme.inherit: false
+                        Kirigami.Theme.colorSet: Kirigami.Theme.Button
                         QQC2.Label {
-                            Layout.fillWidth: true
                             Layout.fillHeight: true
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
-                            wrapMode: Text.Wrap
-                            text: bluetoothSetup.connectedDevice === null ? qsTr("Not\nConnected") : qsTr("Connected to\n%1").arg(bluetoothSetup.connectedDevice.name)
-                        }
-                        QQC2.Button {
-                            icon.name: bluetoothSetup.connectedDevice === null ? "network-bluetooth" : "network-bluetooth-activated"
-                            text: qsTr("Setup")
-                            display: QQC2.AbstractButton.TextBesideIcon
-                            Layout.alignment: Qt.AlignVCenter
-                            Layout.fillWidth: true
-                            onClicked: {
-                                bluetoothSetup.show();
-                            }
-                        }
-                        QQC2.Label {
-                            Layout.fillWidth: true
-                            horizontalAlignment: Text.AlignHCenter
-                            text: qsTr("BT Audio")
-                        }
-                    }
-                }
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit * 4
-                    contentItem: Item {
-                        ColumnLayout {
-                            anchors.fill: parent
-                            SketchpadDial {
-                                Layout.fillWidth: true
-                                Layout.fillHeight: true
-                                Layout.margins: Kirigami.Units.gridUnit
-                                text: qsTr("Reverb")
-                                controlObj: zynqtgui.reverbController
-                                controlProperty: "value"
-                                valueString: qsTr("%1%").arg(dial.value)
-                                knobId: 2
-
-                                dial {
-                                    stepSize: zynqtgui.reverbController.step_size
-                                    from: zynqtgui.reverbController.value_min
-                                    to: zynqtgui.reverbController.value_max
-                                }
-                                onClicked: {
-                                    zynqtgui.editGlobalFX(1);
-                                    popup.close();
-                                }
-                                // Apparently neither of our two global fx picks have presets defined, so... never mind showing the button
-                                // action: QQC2.Action {
-                                //     text: "Preset Name"
-                                //     onTriggered: {
-                                //         zynqtgui.selectGlobalFXPreset(1);
-                                //         popup.close();
-                                //     }
-                                // }
-                            }
-                        }
-                    }
-                }
-
-                Card {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit
-                    Layout.columnSpan: 2
-                    contentItem: RowLayout {
-                        Layout.alignment: Qt.AlignLeft
-                        QQC2.Switch {
-                            Layout.alignment: Qt.AlignVCenter
-                            Layout.preferredHeight: Kirigami.Units.gridUnit * 2
-                            checked: zynqtgui.sketchpad.metronomeEnabled
-                            text: qsTr("Click")
-                            onToggled: {
-                                zynqtgui.sketchpad.metronomeEnabled = checked
-                            }
-                        }
-                        QQC2.Slider {
-                            Layout.alignment: Qt.AlignVCenter
-                            Layout.preferredHeight: Kirigami.Units.gridUnit
-                            Layout.fillWidth: true
-                            enabled: zynqtgui.sketchpad.metronomeEnabled
-                            from: 0
-                            to: 1
-                            value: zynqtgui.sketchpad.metronomeVolume
-                            onValueChanged: zynqtgui.sketchpad.metronomeVolume = value
+                            text: qsTr("DSP Load:")
                         }
                         Item {
+                            Layout.fillHeight: true
                             Layout.fillWidth: true
-                        }
-                    }
-                }
-                QQC2.Button {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    Layout.preferredHeight: Kirigami.Units.gridUnit
-                    text: qsTr("Stop All Notes")
-                    onClicked: zynqtgui.callable_ui_action_simple("ALL_NOTES_OFF")
-                }
-
-                RowLayout {
-                    Layout.columnSpan: 3
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: Kirigami.Units.largeSpacing
-                    Kirigami.Theme.inherit: false
-                    Kirigami.Theme.colorSet: Kirigami.Theme.Button
-                    QQC2.Label {
-                        Layout.fillHeight: true
-                        text: qsTr("DSP Load:")
-                    }
-                    Item {
-                        Layout.fillHeight: true
-                        Layout.fillWidth: true
-                        Private.CardBackground {
-                            anchors {
-                                verticalCenter: parent.verticalCenter
-                                left: parent.left
-                                right: parent.right
-                                margins: 1
-                            }
-                            height: Kirigami.Units.largeSpacing * 2
-                            Rectangle {
+                            Private.CardBackground {
                                 anchors {
-                                    fill: parent
+                                    verticalCenter: parent.verticalCenter
+                                    left: parent.left
+                                    right: parent.right
                                     margins: 1
                                 }
-                                color: "green"
+                                height: Kirigami.Units.largeSpacing * 2
                                 Rectangle {
                                     anchors {
                                         fill: parent
-                                        leftMargin: parent.width * 2 / 3
+                                        margins: 1
                                     }
-                                    color: "yellow"
+                                    color: "green"
                                     Rectangle {
                                         anchors {
                                             fill: parent
                                             leftMargin: parent.width * 2 / 3
                                         }
-                                        color: "red"
+                                        color: "yellow"
+                                        Rectangle {
+                                            anchors {
+                                                fill: parent
+                                                leftMargin: parent.width * 2 / 3
+                                            }
+                                            color: "red"
+                                        }
                                     }
                                 }
-                            }
-                            Rectangle {
-                                anchors {
-                                    top: parent.top
-                                    right: parent.right
-                                    bottom: parent.bottom
-                                    margins: 1
+                                Rectangle {
+                                    anchors {
+                                        top: parent.top
+                                        right: parent.right
+                                        bottom: parent.bottom
+                                        margins: 1
+                                    }
+                                    width: zynqtgui.globalPopupOpened ? (parent.width - 2) * (1 - Zynthbox.MidiRouter.processingLoad) : 0
+                                    color: Kirigami.Theme.backgroundColor
                                 }
-                                width: zynqtgui.globalPopupOpened ? (parent.width - 2) * (1 - Zynthbox.MidiRouter.processingLoad) : 0
-                                color: Kirigami.Theme.backgroundColor
-                            }
-                            QQC2.Label {
-                                anchors {
-                                    fill: parent
-                                    margins: 2
+                                QQC2.Label {
+                                    anchors {
+                                        fill: parent
+                                        margins: 2
+                                    }
+                                    text: zynqtgui.globalPopupOpened ? qsTr("%1%").arg((100 * Zynthbox.MidiRouter.processingLoad).toFixed(1)) : ""
+                                    font.pixelSize: height
                                 }
-                                text: zynqtgui.globalPopupOpened ? qsTr("%1%").arg((100 * Zynthbox.MidiRouter.processingLoad).toFixed(1)) : ""
-                                font.pixelSize: height
                             }
                         }
                     }
                 }
             }
-        }
-        BluetoothConnections {
-            id: bluetoothSetup
-            visible: false
-            anchors.fill: parent
-            Connections {
-                target: zynqtgui
-                onGlobalPopupOpenedChanged: {
-                    if (zynqtgui.globalPopupOpened === false) {
-                        bluetoothSetup.hide();
+            BluetoothConnections {
+                id: bluetoothSetup
+                visible: false
+                anchors.fill: parent
+                Connections {
+                    target: zynqtgui
+                    onGlobalPopupOpenedChanged: {
+                        if (zynqtgui.globalPopupOpened === false) {
+                            bluetoothSetup.hide();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR includes:
- The statusbar element is wrapped into a single control, which can benefit from properties such as background, padding, etc
- The status bar control styling now features a background and border color to make it appear as a clickable target. Now, being a control, the styling can be adjusted more easily.
- The layout is the same, but I've added a ghost-like sound signal bar. So, instead of the previous blank space, it has a placeholder for a visual cue.
- The elements now have clip set to true so they don't overflow
- 