### PR TITLE
Header sections

### DIFF
--- a/qml-ui/main.qml
+++ b/qml-ui/main.qml
@@ -68,273 +68,273 @@ Kirigami.AbstractApplicationWindow {
         }
         if (result === false) {
             switch (cuia) {
-                case "SWITCH_METRONOME_SHORT":
-                    zynqtgui.sketchpad.metronomeEnabled = !zynqtgui.sketchpad.metronomeEnabled
+            case "SWITCH_METRONOME_SHORT":
+                zynqtgui.sketchpad.metronomeEnabled = !zynqtgui.sketchpad.metronomeEnabled
+                result = true;
+                break;
+            case "KNOB0_TOUCHED":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelVolume(0, true)
                     result = true;
-                    break;
-                case "KNOB0_TOUCHED":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelVolume(0, true)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateMetronomeVolume(0)
-                        result = true;
-                    }
-                    break;
-                case "KNOB0_RELEASED":
-                    if (zynqtgui.altButtonPressed) {
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        result = true;
-                    }
-                    break;
-                case "KNOB0_UP":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelVolume(1, true)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateMetronomeVolume(1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB0_DOWN":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelVolume(-1, true)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateMetronomeVolume(-1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB1_TOUCHED":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelDelaySend(0)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        result = true;
-                    }
-                    break;
-                case "KNOB1_RELEASED":
-                    if (zynqtgui.altButtonPressed) {
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        result = true;
-                    }
-                    break;
-                case "KNOB1_UP":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelDelaySend(1)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        // root.updateGlobalDelayFXAmount(1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB1_DOWN":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelDelaySend(-1)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        // root.updateGlobalDelayFXAmount(-1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB2_TOUCHED":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelReverbSend(0)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        result = true;
-                    }
-                    break;
-                case "KNOB2_RELEASED":
-                    if (zynqtgui.altButtonPressed) {
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        result = true;
-                    }
-                    break;
-                case "KNOB2_UP":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelReverbSend(1)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        // root.updateGlobalReverbFXAmount(1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB2_DOWN":
-                    if (zynqtgui.altButtonPressed) {
-                        root.updateSelectedChannelReverbSend(-1)
-                        result = true;
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        // root.updateGlobalReverbFXAmount(-1)
-                        result = true;
-                    }
-                    break;
-                case "KNOB3_TOUCHED":
-                    if (zynqtgui.altButtonPressed) {
-                        // Allows us to use alt+mode as a modifier in stepsequencer
-                        if (zynqtgui.modeButtonPressed === false) {
-                            root.updateMasterVolume(0);
-                            result = true;
-                        }
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateSketchpadBpm(0)
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateMetronomeVolume(0)
+                    result = true;
+                }
+                break;
+            case "KNOB0_RELEASED":
+                if (zynqtgui.altButtonPressed) {
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB0_UP":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelVolume(1, true)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateMetronomeVolume(1)
+                    result = true;
+                }
+                break;
+            case "KNOB0_DOWN":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelVolume(-1, true)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateMetronomeVolume(-1)
+                    result = true;
+                }
+                break;
+            case "KNOB1_TOUCHED":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelDelaySend(0)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB1_RELEASED":
+                if (zynqtgui.altButtonPressed) {
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB1_UP":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelDelaySend(1)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    // root.updateGlobalDelayFXAmount(1)
+                    result = true;
+                }
+                break;
+            case "KNOB1_DOWN":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelDelaySend(-1)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    // root.updateGlobalDelayFXAmount(-1)
+                    result = true;
+                }
+                break;
+            case "KNOB2_TOUCHED":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelReverbSend(0)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB2_RELEASED":
+                if (zynqtgui.altButtonPressed) {
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB2_UP":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelReverbSend(1)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    // root.updateGlobalReverbFXAmount(1)
+                    result = true;
+                }
+                break;
+            case "KNOB2_DOWN":
+                if (zynqtgui.altButtonPressed) {
+                    root.updateSelectedChannelReverbSend(-1)
+                    result = true;
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    // root.updateGlobalReverbFXAmount(-1)
+                    result = true;
+                }
+                break;
+            case "KNOB3_TOUCHED":
+                if (zynqtgui.altButtonPressed) {
+                    // Allows us to use alt+mode as a modifier in stepsequencer
+                    if (zynqtgui.modeButtonPressed === false) {
+                        root.updateMasterVolume(0);
                         result = true;
                     }
-                    break;
-                case "KNOB3_RELEASED":
-                    if (zynqtgui.altButtonPressed) {
-                        // Allows us to use alt+mode as a modifier in stepsequencer
-                        if (zynqtgui.modeButtonPressed === false) {
-                            result = true;
-                        }
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateSketchpadBpm(0)
+                    result = true;
+                }
+                break;
+            case "KNOB3_RELEASED":
+                if (zynqtgui.altButtonPressed) {
+                    // Allows us to use alt+mode as a modifier in stepsequencer
+                    if (zynqtgui.modeButtonPressed === false) {
                         result = true;
                     }
-                    break;
-                case "KNOB3_UP":
-                    if (zynqtgui.altButtonPressed && zynqtgui.globalPopupOpened === false) {
-                        // Allows us to use alt+mode as a modifier in stepsequencer
-                        if (zynqtgui.modeButtonPressed === false) {
-                            root.updateMasterVolume(1);
-                            result = true;
-                        }
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateSketchpadBpm(1)
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    result = true;
+                }
+                break;
+            case "KNOB3_UP":
+                if (zynqtgui.altButtonPressed && zynqtgui.globalPopupOpened === false) {
+                    // Allows us to use alt+mode as a modifier in stepsequencer
+                    if (zynqtgui.modeButtonPressed === false) {
+                        root.updateMasterVolume(1);
                         result = true;
                     }
-                    break;
-                case "KNOB3_DOWN":
-                    if (zynqtgui.altButtonPressed && zynqtgui.globalPopupOpened === false) {
-                        // Allows us to use alt+mode as a modifier in stepsequencer
-                        if (zynqtgui.modeButtonPressed === false) {
-                            root.updateMasterVolume(-1);
-                            result = true;
-                        }
-                    } else if (zynqtgui.metronomeButtonPressed) {
-                        zynqtgui.ignoreNextMetronomeButtonPress = true
-                        root.updateSketchpadBpm(-1)
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateSketchpadBpm(1)
+                    result = true;
+                }
+                break;
+            case "KNOB3_DOWN":
+                if (zynqtgui.altButtonPressed && zynqtgui.globalPopupOpened === false) {
+                    // Allows us to use alt+mode as a modifier in stepsequencer
+                    if (zynqtgui.modeButtonPressed === false) {
+                        root.updateMasterVolume(-1);
                         result = true;
                     }
-                    break;
-                case "NAVIGATE_LEFT":
-                    if (zynqtgui.modeButtonPressed) {
-                        root.selectedChannel.selectedClip = Math.max(0, root.selectedChannel.selectedClip - 1);
-                        zynqtgui.ignoreNextModeButtonPress = true;
-                        result = true;
-                    }
-                    break;
-                case "NAVIGATE_RIGHT":
-                    if (zynqtgui.modeButtonPressed) {
-                        root.selectedChannel.selectedClip = Math.min(Zynthbox.Plugin.sketchpadSlotCount - 1, root.selectedChannel.selectedClip + 1);
-                        zynqtgui.ignoreNextModeButtonPress = true;
-                        result = true;
-                    }
-                    break;
-                case "SCREEN_LAYER":
-                case "SCREEN_PRESET":
-                    if (["layer", "fixed_layers", "main_layers_view", "layers_for_channel", "bank", "preset", "effects_for_channel", "effect_preset", "sketch_effects_for_channel", "sketch_effect_preset", "sample_library"].includes(zynqtgui.current_screen_id) === false) {
-                        if (["TracksBar_sampleslot", "TracksBar_sketchslot"].includes(root.selectedChannel.selectedSlot.className)) {
-                            // Then we are selecting samples and sketches, show the sample library
-                            zynqtgui.show_screen("sample_library");
-                        } else if (root.selectedChannel.selectedSlot.className === "TracksBar_fxslot") {
-                            // Then it's an fx slot and we should show that particular type of preset selector
-                            pageManager.getPage("sketchpad").bottomStack.tracksBar.switchToSlot("fx", root.selectedChannel.selectedSlot.value);
-                            zynqtgui.show_screen("effect_preset");
-                        } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sketchfxslot") {
-                            // Then it's an sketchfx slot and we should show that particular type of preset selector
-                            pageManager.getPage("sketchpad").bottomStack.tracksBar.switchToSlot("sketch-fx", root.selectedChannel.selectedSlot.value);
-                            zynqtgui.show_screen("sketch_effect_preset");
-                        } else {
-                            zynqtgui.show_screen("preset");
-                        }
-                        result = true;
-                    }
-                    break;
-                case "SCREEN_EDIT_CONTEXTUAL":
-                    // In case the global popup is open, hide it when switching to the context editor
-                    zynqtgui.globalPopupOpened = false;
-                    // Ensure we have at least something selected before we attempt to switch
-                    pageManager.getPage("sketchpad").bottomStack.tracksBar.pickFirstAndBestSlot(false);
-                    if (root.selectedChannel.selectedSlot.className === "TracksBar_synthslot") {
-                        var sound = root.selectedChannel.chainedSounds[root.selectedChannel.selectedSlot.value];
-                        if (sound >= 0 && root.selectedChannel.checkIfLayerExists(sound)) {
-                            zynqtgui.show_screen("control");
-                        } else {
-                            applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
-                        }
-                    } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sampleslot") {
-                        zynqtgui.show_modal("channel_wave_editor");
-                    } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sketchslot") {
-                        zynqtgui.show_modal("channel_wave_editor");
-                    } else if (root.selectedChannel.selectedSlot.className === "TracksBar_externalslot") {
-                         zynqtgui.show_modal("channel_external_setup");
+                } else if (zynqtgui.metronomeButtonPressed) {
+                    zynqtgui.ignoreNextMetronomeButtonPress = true
+                    root.updateSketchpadBpm(-1)
+                    result = true;
+                }
+                break;
+            case "NAVIGATE_LEFT":
+                if (zynqtgui.modeButtonPressed) {
+                    root.selectedChannel.selectedClip = Math.max(0, root.selectedChannel.selectedClip - 1);
+                    zynqtgui.ignoreNextModeButtonPress = true;
+                    result = true;
+                }
+                break;
+            case "NAVIGATE_RIGHT":
+                if (zynqtgui.modeButtonPressed) {
+                    root.selectedChannel.selectedClip = Math.min(Zynthbox.Plugin.sketchpadSlotCount - 1, root.selectedChannel.selectedClip + 1);
+                    zynqtgui.ignoreNextModeButtonPress = true;
+                    result = true;
+                }
+                break;
+            case "SCREEN_LAYER":
+            case "SCREEN_PRESET":
+                if (["layer", "fixed_layers", "main_layers_view", "layers_for_channel", "bank", "preset", "effects_for_channel", "effect_preset", "sketch_effects_for_channel", "sketch_effect_preset", "sample_library"].includes(zynqtgui.current_screen_id) === false) {
+                    if (["TracksBar_sampleslot", "TracksBar_sketchslot"].includes(root.selectedChannel.selectedSlot.className)) {
+                        // Then we are selecting samples and sketches, show the sample library
+                        zynqtgui.show_screen("sample_library");
                     } else if (root.selectedChannel.selectedSlot.className === "TracksBar_fxslot") {
-                        if (root.selectedChannel.chainedFx[root.selectedChannel.selectedSlot.value] != null) {
-                            zynqtgui.show_screen("control");
-                        } else {
-                            applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
-                        }
+                        // Then it's an fx slot and we should show that particular type of preset selector
+                        pageManager.getPage("sketchpad").bottomStack.tracksBar.switchToSlot("fx", root.selectedChannel.selectedSlot.value);
+                        zynqtgui.show_screen("effect_preset");
                     } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sketchfxslot") {
-                        if (root.selectedChannel.chainedSketchFx[root.selectedChannel.selectedSlot.value] != null) {
-                            zynqtgui.show_screen("control");
-                        } else {
-                            applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
-                        }
+                        // Then it's an sketchfx slot and we should show that particular type of preset selector
+                        pageManager.getPage("sketchpad").bottomStack.tracksBar.switchToSlot("sketch-fx", root.selectedChannel.selectedSlot.value);
+                        zynqtgui.show_screen("sketch_effect_preset");
                     } else {
-                        if (root.selectedChannel.trackType.startsWith("sample-")) {
-                            // If we are in any sample mode, switch whatever else is going on (as that page knows what to do about it)
-                            if (root.selectedChannel.trackType === "sample-loop") {
-                                root.selectedChannel.selectedSlotRow = root.selectedChannel.selectedClip;
-                            } else {
-                                for (let slotIndex = 0; slotIndex < Zynthbox.Plugin.sketchpadSlotCount; ++slotIndex) {
-                                    if (root.selectedChannel.samples[slotIndex].cppObjId > -1) {
-                                        // Let's at least make sure there's some sample selected
-                                        root.selectedChannel.selectedSlotRow = slotIndex;
-                                        break;
-                                    }
-                                }
-                            }
-                            zynqtgui.show_modal("channel_wave_editor");
-                        } else if (root.selectedChannel.trackType === "synth") {
-                            // If we are in synth mode, select the first slot explicitly and then switch to the control page, and if there isn't one... throw up the warning
-                            let foundASound = false;
+                        zynqtgui.show_screen("preset");
+                    }
+                    result = true;
+                }
+                break;
+            case "SCREEN_EDIT_CONTEXTUAL":
+                // In case the global popup is open, hide it when switching to the context editor
+                zynqtgui.globalPopupOpened = false;
+                // Ensure we have at least something selected before we attempt to switch
+                pageManager.getPage("sketchpad").bottomStack.tracksBar.pickFirstAndBestSlot(false);
+                if (root.selectedChannel.selectedSlot.className === "TracksBar_synthslot") {
+                    var sound = root.selectedChannel.chainedSounds[root.selectedChannel.selectedSlot.value];
+                    if (sound >= 0 && root.selectedChannel.checkIfLayerExists(sound)) {
+                        zynqtgui.show_screen("control");
+                    } else {
+                        applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
+                    }
+                } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sampleslot") {
+                    zynqtgui.show_modal("channel_wave_editor");
+                } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sketchslot") {
+                    zynqtgui.show_modal("channel_wave_editor");
+                } else if (root.selectedChannel.selectedSlot.className === "TracksBar_externalslot") {
+                    zynqtgui.show_modal("channel_external_setup");
+                } else if (root.selectedChannel.selectedSlot.className === "TracksBar_fxslot") {
+                    if (root.selectedChannel.chainedFx[root.selectedChannel.selectedSlot.value] != null) {
+                        zynqtgui.show_screen("control");
+                    } else {
+                        applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
+                    }
+                } else if (root.selectedChannel.selectedSlot.className === "TracksBar_sketchfxslot") {
+                    if (root.selectedChannel.chainedSketchFx[root.selectedChannel.selectedSlot.value] != null) {
+                        zynqtgui.show_screen("control");
+                    } else {
+                        applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
+                    }
+                } else {
+                    if (root.selectedChannel.trackType.startsWith("sample-")) {
+                        // If we are in any sample mode, switch whatever else is going on (as that page knows what to do about it)
+                        if (root.selectedChannel.trackType === "sample-loop") {
+                            root.selectedChannel.selectedSlotRow = root.selectedChannel.selectedClip;
+                        } else {
                             for (let slotIndex = 0; slotIndex < Zynthbox.Plugin.sketchpadSlotCount; ++slotIndex) {
-                                let sound = root.selectedChannel.chainedSounds[slotIndex];
-                                if (sound >= 0 && root.selectedChannel.checkIfLayerExists(sound)) {
-                                    root.selectedChannel.selectedSlotRow = sound;
-                                    zynqtgui.show_screen("control");
-                                    foundASound = true;
+                                if (root.selectedChannel.samples[slotIndex].cppObjId > -1) {
+                                    // Let's at least make sure there's some sample selected
+                                    root.selectedChannel.selectedSlotRow = slotIndex;
                                     break;
                                 }
                             }
-                            if (foundASound === false) {
-                                applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
-                            }
-                        } else if (root.selectedChannel.trackType === "external") {
-                            // If we are in external mode, just load up the external setup page
-                            show_modal("channel_external_setup");
                         }
+                        zynqtgui.show_modal("channel_wave_editor");
+                    } else if (root.selectedChannel.trackType === "synth") {
+                        // If we are in synth mode, select the first slot explicitly and then switch to the control page, and if there isn't one... throw up the warning
+                        let foundASound = false;
+                        for (let slotIndex = 0; slotIndex < Zynthbox.Plugin.sketchpadSlotCount; ++slotIndex) {
+                            let sound = root.selectedChannel.chainedSounds[slotIndex];
+                            if (sound >= 0 && root.selectedChannel.checkIfLayerExists(sound)) {
+                                root.selectedChannel.selectedSlotRow = sound;
+                                zynqtgui.show_screen("control");
+                                foundASound = true;
+                                break;
+                            }
+                        }
+                        if (foundASound === false) {
+                            applicationWindow().showMessageDialog(qsTr("Cannot open edit page: All slots are empty"), 2000);
+                        }
+                    } else if (root.selectedChannel.trackType === "external") {
+                        // If we are in external mode, just load up the external setup page
+                        show_modal("channel_external_setup");
                     }
-                    returnValue = true;
-                    break;
+                }
+                returnValue = true;
+                break;
             }
         }
 
@@ -434,22 +434,22 @@ Kirigami.AbstractApplicationWindow {
         var _params = Object.assign({}, defaults, params)
 
         zynqtgui.osd.updateOsd(
-            _params.parameterName,
-            _params.description,
-            _params.start,
-            _params.stop,
-            _params.step,
-            _params.defaultValue,
-            _params.currentValue,
-            _params.setValueFunction,
-            _params.startLabel,
-            _params.stopLabel,
-            _params.valueLabel,
-            _params.showValueLabel,
-            _params.visualZero,
-            _params.showResetToDefault,
-            _params.showVisualZero,
-        )
+                    _params.parameterName,
+                    _params.description,
+                    _params.start,
+                    _params.stop,
+                    _params.step,
+                    _params.defaultValue,
+                    _params.currentValue,
+                    _params.setValueFunction,
+                    _params.startLabel,
+                    _params.stopLabel,
+                    _params.valueLabel,
+                    _params.showValueLabel,
+                    _params.visualZero,
+                    _params.showResetToDefault,
+                    _params.showVisualZero,
+                    )
     }
 
     /**
@@ -461,19 +461,19 @@ Kirigami.AbstractApplicationWindow {
             zynqtgui.masterVolume = Zynthian.CommonUtils.clamp(value, 0, 100)
             if (!zynqtgui.globalPopupOpened) {
                 applicationWindow().showOsd({
-                    parameterName: "master_volume",
-                    description: qsTr("Master Volume"),
-                    start: 0,
-                    stop: 100,
-                    step: 1,
-                    defaultValue: null,
-                    currentValue: zynqtgui.masterVolume,
-                    valueLabel: parseInt(zynqtgui.masterVolume),
-                    setValueFunction: valueSetter,
-                    showValueLabel: true,
-                    showResetToDefault: false,
-                    showVisualZero: false
-                })
+                                                parameterName: "master_volume",
+                                                description: qsTr("Master Volume"),
+                                                start: 0,
+                                                stop: 100,
+                                                step: 1,
+                                                defaultValue: null,
+                                                currentValue: zynqtgui.masterVolume,
+                                                valueLabel: parseInt(zynqtgui.masterVolume),
+                                                setValueFunction: valueSetter,
+                                                showValueLabel: true,
+                                                showResetToDefault: false,
+                                                showVisualZero: false
+                                            })
             }
         }
         valueSetter(zynqtgui.masterVolume + sign)
@@ -486,19 +486,19 @@ Kirigami.AbstractApplicationWindow {
         function valueSetter(value) {
             zynqtgui.sketchpad.metronomeVolume = Zynthian.CommonUtils.clamp(value, 0, 1)
             applicationWindow().showOsd({
-                parameterName: "metronome_volume",
-                description: qsTr("Metronome Volume"),
-                start: 0,
-                stop: 1,
-                step: 0.01,
-                defaultValue: null,
-                currentValue: zynqtgui.sketchpad.metronomeVolume,
-                valueLabel: zynqtgui.sketchpad.metronomeVolume.toFixed(2),
-                setValueFunction: valueSetter,
-                showValueLabel: true,
-                showResetToDefault: false,
-                showVisualZero: false
-            })
+                                            parameterName: "metronome_volume",
+                                            description: qsTr("Metronome Volume"),
+                                            start: 0,
+                                            stop: 1,
+                                            step: 0.01,
+                                            defaultValue: null,
+                                            currentValue: zynqtgui.sketchpad.metronomeVolume,
+                                            valueLabel: zynqtgui.sketchpad.metronomeVolume.toFixed(2),
+                                            setValueFunction: valueSetter,
+                                            showValueLabel: true,
+                                            showResetToDefault: false,
+                                            showVisualZero: false
+                                        })
         }
         valueSetter(zynqtgui.sketchpad.metronomeVolume + sign * 0.01)
     }
@@ -511,19 +511,19 @@ Kirigami.AbstractApplicationWindow {
             zynqtgui.delayController.value = Zynthian.CommonUtils.clamp(value, 0, 100)
             if (!zynqtgui.globalPopupOpened) {
                 applicationWindow().showOsd({
-                    parameterName: "global_delay_fx_amount",
-                    description: qsTr("Global Delay FX Amount"),
-                    start: 0,
-                    stop: 100,
-                    step: 1,
-                    defaultValue: 10,
-                    currentValue: zynqtgui.delayController.value,
-                    valueLabel: parseInt(zynqtgui.delayController.value),
-                    setValueFunction: valueSetter,
-                    showValueLabel: true,
-                    showResetToDefault: true,
-                    showVisualZero: false
-                })
+                                                parameterName: "global_delay_fx_amount",
+                                                description: qsTr("Global Delay FX Amount"),
+                                                start: 0,
+                                                stop: 100,
+                                                step: 1,
+                                                defaultValue: 10,
+                                                currentValue: zynqtgui.delayController.value,
+                                                valueLabel: parseInt(zynqtgui.delayController.value),
+                                                setValueFunction: valueSetter,
+                                                showValueLabel: true,
+                                                showResetToDefault: true,
+                                                showVisualZero: false
+                                            })
             }
         }
         valueSetter(zynqtgui.delayController.value + sign)
@@ -537,19 +537,19 @@ Kirigami.AbstractApplicationWindow {
             zynqtgui.reverbController.value = Zynthian.CommonUtils.clamp(value, 0, 100)
             if (!zynqtgui.globalPopupOpened) {
                 applicationWindow().showOsd({
-                    parameterName: "global_reverb_fx_amount",
-                    description: qsTr("Global ReverbFX Amount"),
-                    start: 0,
-                    stop: 100,
-                    step: 1,
-                    defaultValue: 10,
-                    currentValue: zynqtgui.reverbController.value,
-                    valueLabel: parseInt(zynqtgui.reverbController.value),
-                    setValueFunction: valueSetter,
-                    showValueLabel: true,
-                    showResetToDefault: true,
-                    showVisualZero: false
-                })
+                                                parameterName: "global_reverb_fx_amount",
+                                                description: qsTr("Global ReverbFX Amount"),
+                                                start: 0,
+                                                stop: 100,
+                                                step: 1,
+                                                defaultValue: 10,
+                                                currentValue: zynqtgui.reverbController.value,
+                                                valueLabel: parseInt(zynqtgui.reverbController.value),
+                                                setValueFunction: valueSetter,
+                                                showValueLabel: true,
+                                                showResetToDefault: true,
+                                                showVisualZero: false
+                                            })
             }
         }
         valueSetter(zynqtgui.reverbController.value + sign)
@@ -573,20 +573,20 @@ Kirigami.AbstractApplicationWindow {
             }
             if (!zynqtgui.globalPopupOpened) {
                 applicationWindow().showOsd({
-                    parameterName: "sketchpad_bpm",
-                    description: qsTr("%1 bpm").arg(zynqtgui.sketchpad.song.name),
-                    start: 50,
-                    stop: 200,
-                    step: 1,
-                    defaultValue: 120,
-                    visualZero: 50,
-                    currentValue: Zynthbox.SyncTimer.bpm,
-                    valueLabel: parseInt(Zynthbox.SyncTimer.bpm),
-                    setValueFunction: valueSetter,
-                    showValueLabel: true,
-                    showResetToDefault: false,
-                    showVisualZero: false
-                })
+                                                parameterName: "sketchpad_bpm",
+                                                description: qsTr("%1 bpm").arg(zynqtgui.sketchpad.song.name),
+                                                start: 50,
+                                                stop: 200,
+                                                step: 1,
+                                                defaultValue: 120,
+                                                visualZero: 50,
+                                                currentValue: Zynthbox.SyncTimer.bpm,
+                                                valueLabel: parseInt(Zynthbox.SyncTimer.bpm),
+                                                setValueFunction: valueSetter,
+                                                showValueLabel: true,
+                                                showResetToDefault: false,
+                                                showVisualZero: false
+                                            })
             }
         }
         valueSetter(sign)
@@ -600,22 +600,22 @@ Kirigami.AbstractApplicationWindow {
             root.selectedChannel.gainHandler.gainAbsolute = Zynthian.CommonUtils.clamp(value, 0, 1)
             if (showOsd) {
                 applicationWindow().showOsd({
-                    parameterName: "channel_volume",
-                    description: qsTr("%1 Volume").arg(root.selectedChannel.name),
-                    start: 0,
-                    stop: 1,
-                    step: 0.01,
-                    defaultValue: parseFloat(root.selectedChannel.gainHandler.absoluteGainAtZeroDb),
-                    currentValue: parseFloat(root.selectedChannel.gainHandler.gainAbsolute),
-                    startLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.minimumDecibel),
-                    stopLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.maximumDecibel),
-                    valueLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.gainDb.toFixed(2)),
-                    setValueFunction: valueSetter,
-                    showValueLabel: true,
-                    showResetToDefault: true,
-                    visualZero: parseFloat(root.selectedChannel.gainHandler.absoluteGainAtZeroDb),
-                    showVisualZero: true
-                })
+                                                parameterName: "channel_volume",
+                                                description: qsTr("%1 Volume").arg(root.selectedChannel.name),
+                                                start: 0,
+                                                stop: 1,
+                                                step: 0.01,
+                                                defaultValue: parseFloat(root.selectedChannel.gainHandler.absoluteGainAtZeroDb),
+                                                currentValue: parseFloat(root.selectedChannel.gainHandler.gainAbsolute),
+                                                startLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.minimumDecibel),
+                                                stopLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.maximumDecibel),
+                                                valueLabel: qsTr("%1 dB").arg(root.selectedChannel.gainHandler.gainDb.toFixed(2)),
+                                                setValueFunction: valueSetter,
+                                                showValueLabel: true,
+                                                showResetToDefault: true,
+                                                visualZero: parseFloat(root.selectedChannel.gainHandler.absoluteGainAtZeroDb),
+                                                showVisualZero: true
+                                            })
             }
         }
 
@@ -629,19 +629,19 @@ Kirigami.AbstractApplicationWindow {
         function valueSetter(value) {
             root.selectedChannel.wetFx1Amount = Zynthian.CommonUtils.clamp(value, 0, 100)
             applicationWindow().showOsd({
-                parameterName: "channel_delay_send",
-                description: qsTr("%1 Delay FX Send Amount").arg(root.selectedChannel.name),
-                start: 0,
-                stop: 100,
-                step: 1,
-                defaultValue: 100,
-                currentValue: root.selectedChannel.wetFx1Amount,
-                valueLabel: parseInt(root.selectedChannel.wetFx1Amount),
-                setValueFunction: valueSetter,
-                showValueLabel: true,
-                showResetToDefault: true,
-                showVisualZero: true
-            })
+                                            parameterName: "channel_delay_send",
+                                            description: qsTr("%1 Delay FX Send Amount").arg(root.selectedChannel.name),
+                                            start: 0,
+                                            stop: 100,
+                                            step: 1,
+                                            defaultValue: 100,
+                                            currentValue: root.selectedChannel.wetFx1Amount,
+                                            valueLabel: parseInt(root.selectedChannel.wetFx1Amount),
+                                            setValueFunction: valueSetter,
+                                            showValueLabel: true,
+                                            showResetToDefault: true,
+                                            showVisualZero: true
+                                        })
         }
 
         valueSetter(root.selectedChannel.wetFx1Amount + sign)
@@ -654,19 +654,19 @@ Kirigami.AbstractApplicationWindow {
         function valueSetter(value) {
             root.selectedChannel.wetFx2Amount = Zynthian.CommonUtils.clamp(value, 0, 100)
             applicationWindow().showOsd({
-                parameterName: "channel_reverb_send",
-                description: qsTr("%1 Reverb FX Send Amount").arg(root.selectedChannel.name),
-                start: 0,
-                stop: 100,
-                step: 1,
-                defaultValue: 100,
-                currentValue: root.selectedChannel.wetFx2Amount,
-                valueLabel: parseInt(root.selectedChannel.wetFx2Amount),
-                setValueFunction: valueSetter,
-                showValueLabel: true,
-                showResetToDefault: true,
-                showVisualZero: true
-            })
+                                            parameterName: "channel_reverb_send",
+                                            description: qsTr("%1 Reverb FX Send Amount").arg(root.selectedChannel.name),
+                                            start: 0,
+                                            stop: 100,
+                                            step: 1,
+                                            defaultValue: 100,
+                                            currentValue: root.selectedChannel.wetFx2Amount,
+                                            valueLabel: parseInt(root.selectedChannel.wetFx2Amount),
+                                            setValueFunction: valueSetter,
+                                            showValueLabel: true,
+                                            showResetToDefault: true,
+                                            showVisualZero: true
+                                        })
         }
 
         valueSetter(root.selectedChannel.wetFx2Amount + sign)
@@ -680,388 +680,443 @@ Kirigami.AbstractApplicationWindow {
     onWidthChanged: width = screen.width
     onHeightChanged: height = screen.height
     pageStack: pageManager
-    header: RowLayout {            
-        spacing: 0
-        Zynthian.BreadcrumbButton {
-            id: menuButton
-            icon.name: "application-menu"
-            icon.color: Kirigami.Theme.textColor
-            padding: Kirigami.Units.largeSpacing*1.5
-            rightPadding: Kirigami.Units.largeSpacing*1.5
-            property string oldPage: "sketchpad"
-            property string oldModalPage: "sketchpad"
-            onClicked: {
-                if (zynqtgui.current_screen_id === 'main') {
-                    if (oldModalPage !== "") {
-                        zynqtgui.current_modal_screen_id = oldModalPage;
-                    } else if (oldPage !== "") {
-                        zynqtgui.current_screen_id = oldPage;
-                    }
-                } else {
-                    if (zynqtgui.current_screen_id === "control") {
-                        oldModalPage = "";
-                        oldPage = "preset"
-                    } else {
-                        oldModalPage = zynqtgui.current_modal_screen_id;
-                        oldPage = zynqtgui.current_screen_id;
-                    }
-                    zynqtgui.current_screen_id = 'main';
-                }
+    header: QQC2.Pane {
+        padding: 0
+        background: Rectangle {
+            Kirigami.Theme.colorSet: Kirigami.Theme.Window
+            Kirigami.Theme.inherit: false
+            color:  Qt.lighter(Kirigami.Theme.alternateBackgroundColor,1.5)
+            Kirigami.Separator
+            {
+                color: Qt.darker(Kirigami.Theme.backgroundColor, 1.5)
+                width: parent.width
+                height: 1
+                anchors.bottom: parent.bottom
             }
-            highlighted: zynqtgui.current_screen_id === 'main'
         }
-        Zynthian.BreadcrumbButton {
-            id: homeButton
-            Layout.minimumWidth: Kirigami.Units.gridUnit * 6
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 6
-            padding: Kirigami.Units.largeSpacing*1.5
-            rightPadding: Kirigami.Units.largeSpacing*1.5
-            font.pointSize: 11
-            onClicked: {
-                if (zynqtgui.current_modal_screen_id == "sketchpad") {
-                    root.showMessageDialog(zynqtgui.sketchpad.song.sketchpadFolder+zynqtgui.sketchpad.song.name+".sketchpad.json", 0)
-                } else {
-                    zynqtgui.current_modal_screen_id = 'sketchpad'
-                }
-            }
-            QQC2.Label {
-                anchors.fill: parent
-                anchors.margins: Kirigami.Units.largeSpacing
-                horizontalAlignment: QQC2.Label.AlignHCenter
-                verticalAlignment: QQC2.Label.AlignVCenter
-                elide: Text.ElideMiddle
-                wrapMode: QQC2.Label.WrapAnywhere
-                font.pointSize: 10
-                minimumPointSize: 5
-                fontSizeMode: Text.Fit
-                maximumLineCount: 3
-                text: qsTr("%1 %2").arg(zynqtgui.sketchpad.song.name).arg(zynqtgui.sketchpad.song.hasUnsavedChanges ? "(*)" : "")
-            }
 
-            Zynthian.Menu {
-                id: tracksMenu
-                y: parent.height
-                modal: true
-                dim: false
-                Repeater {
-                    model: 10
-                    delegate: QQC2.MenuItem {
-                        text: qsTr("Track T%1").arg(index+1)
-                        width: parent.width
+        contentItem: RowLayout {
+            spacing: 0
+
+            QQC2.Control
+            {
+                Layout.fillHeight: true
+                Layout.margins: Kirigami.Units.smallSpacing
+                Layout.leftMargin: 0
+                padding: 0
+                clip: true
+                background: null
+                // background: Rectangle
+                // {
+                //     Kirigami.Theme.colorSet: Kirigami.Theme.Button
+                //     Kirigami.Theme.inherit: false
+                //     color: Kirigami.Theme.alternateBackgroundColor
+                //     radius: 4
+                //     border.color: Qt.darker(Kirigami.Theme.alternateBackgroundColor, 1.5)
+                // }
+
+                contentItem: RowLayout
+                {
+                    spacing: 0
+                    Zynthian.BreadcrumbButton {
+                        id: menuButton
+                        icon.name: "application-menu"
+                        padding: Kirigami.Units.largeSpacing*1.5
+                        rightPadding: Kirigami.Units.largeSpacing*1.5
+                        property string oldPage: "sketchpad"
+                        property string oldModalPage: "sketchpad"
+                        onClicked: {
+                            if (zynqtgui.current_screen_id === 'main') {
+                                if (oldModalPage !== "") {
+                                    zynqtgui.current_modal_screen_id = oldModalPage;
+                                } else if (oldPage !== "") {
+                                    zynqtgui.current_screen_id = oldPage;
+                                }
+                            } else {
+                                if (zynqtgui.current_screen_id === "control") {
+                                    oldModalPage = "";
+                                    oldPage = "preset"
+                                } else {
+                                    oldModalPage = zynqtgui.current_modal_screen_id;
+                                    oldPage = zynqtgui.current_screen_id;
+                                }
+                                zynqtgui.current_screen_id = 'main';
+                            }
+                        }
+                        highlighted: zynqtgui.current_screen_id === 'main'
+                    }
+                    Zynthian.BreadcrumbButton {
+                        id: homeButton
+                        Layout.minimumWidth: Kirigami.Units.gridUnit * 6
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 6
+                        padding: Kirigami.Units.largeSpacing*1.5
+                        rightPadding: Kirigami.Units.largeSpacing*1.5
                         font.pointSize: 11
                         onClicked: {
-                            tracksMenu.close();
-                            zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex = index;
+                            if (zynqtgui.current_modal_screen_id == "sketchpad") {
+                                root.showMessageDialog(zynqtgui.sketchpad.song.sketchpadFolder+zynqtgui.sketchpad.song.name+".sketchpad.json", 0)
+                            } else {
+                                zynqtgui.current_modal_screen_id = 'sketchpad'
+                            }
                         }
-                        highlighted: zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex === index
+                        QQC2.Label {
+                            anchors.fill: parent
+                            anchors.margins: Kirigami.Units.largeSpacing
+                            horizontalAlignment: QQC2.Label.AlignHCenter
+                            verticalAlignment: QQC2.Label.AlignVCenter
+                            elide: Text.ElideMiddle
+                            wrapMode: QQC2.Label.WrapAnywhere
+                            font.pointSize: 10
+                            minimumPointSize: 5
+                            fontSizeMode: Text.Fit
+                            maximumLineCount: 3
+                            text: qsTr("%1 %2").arg(zynqtgui.sketchpad.song.name).arg(zynqtgui.sketchpad.song.hasUnsavedChanges ? "(*)" : "")
+                        }
+
+                        Zynthian.Menu {
+                            id: tracksMenu
+                            y: parent.height
+                            modal: true
+                            dim: false
+                            Repeater {
+                                model: 10
+                                delegate: QQC2.MenuItem {
+                                    text: qsTr("Track T%1").arg(index+1)
+                                    width: parent.width
+                                    font.pointSize: 11
+                                    onClicked: {
+                                        tracksMenu.close();
+                                        zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex = index;
+                                    }
+                                    highlighted: zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex === index
+                                }
+                            }
+                        }
                     }
-                }
-            }
-        }
-        Zynthian.BreadcrumbButton {
-            id: sceneButton
-            icon.color: Kirigami.Theme.textColor
-            text: qsTr("Scene %1 ˬ").arg(zynqtgui.sketchpad.song.scenesModel.selectedSceneName)
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 6
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            onClicked: scenesMenu.visible = true
-
-            Timer {
-                id: switchTimer
-
-                property int index
-
-                interval: 100
-                repeat: false
-                onTriggered: {
-                    Zynthian.CommonUtils.switchToScene(index)
-                }
-            }
-
-            Zynthian.Menu {
-                id: scenesMenu
-                y: parent.height
-                modal: true
-                dim: false
-                Repeater {
-                    model: 10
-                    delegate: QQC2.MenuItem {
-                        text: qsTr("Scene %1").arg(String.fromCharCode(index+65).toUpperCase())
-                        width: parent.width
+                    Zynthian.BreadcrumbButton {
+                        id: sceneButton
+                        icon.color: Kirigami.Theme.textColor
+                        text: qsTr("Scene %1 ˬ").arg(zynqtgui.sketchpad.song.scenesModel.selectedSceneName)
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 6
+                        rightPadding: Kirigami.Units.largeSpacing*2
                         font.pointSize: 11
-                        onClicked: {
-                            scenesMenu.close();
-                            switchTimer.index = index;
-                            switchTimer.restart();
+                        onClicked: scenesMenu.visible = true
+
+                        Timer {
+                            id: switchTimer
+
+                            property int index
+
+                            interval: 100
+                            repeat: false
+                            onTriggered: {
+                                Zynthian.CommonUtils.switchToScene(index)
+                            }
                         }
-                        highlighted: zynqtgui.sketchpad.song.scenesModel.selectedSceneIndex === index
-//                             implicitWidth: menuItemLayout.implicitWidth + leftPadding + rightPadding
-                    }
-                }
-            }
-        }
-        Zynthian.BreadcrumbButton {
-            id: channelButton
-            icon.color: Kirigami.Theme.textColor
-            text: qsTr("Track %1 ˬ")
-                    .arg(zynqtgui.sketchpad.selectedTrackId+1)
 
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 6
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            onClicked: channelsMenu.visible = true
-            Zynthian.Menu {
-                id: channelsMenu
-                y: parent.height
-                modal: true
-                dim: false
-                Component.onCompleted: zynqtgui.fixed_layers.layers_count = 15;
-                Repeater {
-                    model: zynqtgui.sketchpad.song.channelsModel
-                    delegate: QQC2.MenuItem {
-                        text: qsTr("Track %1").arg(index + 1)
-                        width: parent.width
-                        onClicked: {
-                            zynqtgui.sketchpad.selectedTrackId = index;
+                        Zynthian.Menu {
+                            id: scenesMenu
+                            y: parent.height
+                            modal: true
+                            dim: false
+                            Repeater {
+                                model: 10
+                                delegate: QQC2.MenuItem {
+                                    text: qsTr("Scene %1").arg(String.fromCharCode(index+65).toUpperCase())
+                                    width: parent.width
+                                    font.pointSize: 11
+                                    onClicked: {
+                                        scenesMenu.close();
+                                        switchTimer.index = index;
+                                        switchTimer.restart();
+                                    }
+                                    highlighted: zynqtgui.sketchpad.song.scenesModel.selectedSceneIndex === index
+                                    //                             implicitWidth: menuItemLayout.implicitWidth + leftPadding + rightPadding
+                                }
+                            }
                         }
-                        highlighted: zynqtgui.sketchpad.selectedTrackId === index
                     }
-                }
-            }
-        }
-        Zynthian.BreadcrumbButton {
-            id: samplesButton
+                    Zynthian.BreadcrumbButton {
+                        id: channelButton
+                        icon.color: Kirigami.Theme.textColor
+                        text: qsTr("Track %1 ˬ")
+                        .arg(zynqtgui.sketchpad.selectedTrackId+1)
 
-            property QtObject selectedSample: null
-            Timer {
-                id: samplesButtonThrottle
-                interval: 1; running: false; repeat: false;
-                onTriggered: {
-                     root.selectedChannel.samples[root.selectedChannel.selectedSlotRow]
-                }
-            }
-            Connections {
-                target: root.selectedChannel
-                onSamples_changed: samplesButtonThrottle.restart()
-                onSelectedSlotRowChanged: samplesButtonThrottle.restart()
-            }
-            Component.onCompleted: {
-                samplesButtonThrottle.restart();
-            }
-
-            icon.color: Kirigami.Theme.textColor
-            text: qsTr("Sample %1 ˬ %2")
-                    .arg(root.selectedChannel.selectedSlotRow + 1)
-                    .arg(selectedSample && !selectedSample.isEmpty ? "" : ": none")
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 11
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            onClicked: samplesMenu.visible = true
-            visible: root.selectedChannel.trackType == "sample-trig"
-
-            Zynthian.Menu {
-                id: samplesMenu
-                y: parent.height
-                modal: true
-                dim: false
-                Repeater {
-                    model: 5
-                    delegate: QQC2.MenuItem {
-                        text: qsTr("Sample %1").arg(index + 1)
-                        width: parent.width
-                        onClicked: {
-                            root.selectedChannel.selectedSlotRow = index
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 6
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                        onClicked: channelsMenu.visible = true
+                        Zynthian.Menu {
+                            id: channelsMenu
+                            y: parent.height
+                            modal: true
+                            dim: false
+                            Component.onCompleted: zynqtgui.fixed_layers.layers_count = 15;
+                            Repeater {
+                                model: zynqtgui.sketchpad.song.channelsModel
+                                delegate: QQC2.MenuItem {
+                                    text: qsTr("Track %1").arg(index + 1)
+                                    width: parent.width
+                                    onClicked: {
+                                        zynqtgui.sketchpad.selectedTrackId = index;
+                                    }
+                                    highlighted: zynqtgui.sketchpad.selectedTrackId === index
+                                }
+                            }
                         }
-                        highlighted: root.selectedChannel.selectedSlotRow === index
+                    }
+                    Zynthian.BreadcrumbButton {
+                        id: samplesButton
+
+                        property QtObject selectedSample: null
+                        Timer {
+                            id: samplesButtonThrottle
+                            interval: 1; running: false; repeat: false;
+                            onTriggered: {
+                                root.selectedChannel.samples[root.selectedChannel.selectedSlotRow]
+                            }
+                        }
+                        Connections {
+                            target: root.selectedChannel
+                            onSamples_changed: samplesButtonThrottle.restart()
+                            onSelectedSlotRowChanged: samplesButtonThrottle.restart()
+                        }
+                        Component.onCompleted: {
+                            samplesButtonThrottle.restart();
+                        }
+
+                        icon.color: Kirigami.Theme.textColor
+                        text: qsTr("Sample %1 ˬ %2")
+                        .arg(root.selectedChannel.selectedSlotRow + 1)
+                        .arg(selectedSample && !selectedSample.isEmpty ? "" : ": none")
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 11
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                        onClicked: samplesMenu.visible = true
+                        visible: root.selectedChannel.trackType == "sample-trig"
+
+                        Zynthian.Menu {
+                            id: samplesMenu
+                            y: parent.height
+                            modal: true
+                            dim: false
+                            Repeater {
+                                model: 5
+                                delegate: QQC2.MenuItem {
+                                    text: qsTr("Sample %1").arg(index + 1)
+                                    width: parent.width
+                                    onClicked: {
+                                        root.selectedChannel.selectedSlotRow = index
+                                    }
+                                    highlighted: root.selectedChannel.selectedSlotRow === index
+                                }
+                            }
+                        }
+                    }
+                    Zynthian.BreadcrumbButton {
+                        id: sampleLoopButton
+
+                        property QtObject clip: zynqtgui.sketchpad.song.getClip(zynqtgui.sketchpad.selectedTrackId, zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex)
+
+                        icon.color: Kirigami.Theme.textColor
+                        text: qsTr("%1").arg(clip && clip.filename ? clip.filename : "")
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 10
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                        visible: root.selectedChannel.trackType === "sample-loop"
+                    }
+                    Zynthian.BreadcrumbButton {
+                        id: synthButton
+                        icon.color: Kirigami.Theme.textColor
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 6
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                        visible: root.selectedChannel.trackType === "synth" && zynqtgui.curlayerEngineName.length > 0
+                        Component.onCompleted: synthButton.updateSoundName();
+                        // Open preset screen on clicking this synth button
+                        onClicked: {
+                            if (zynqtgui.curlayerIsFX) {
+                                zynqtgui.show_screen("effect_preset")
+                            } else {
+                                zynqtgui.show_screen("preset")
+                            }
+                        }
+
+                        Connections {
+                            target: zynqtgui.fixed_layers
+                            onList_updated: {
+                                synthButton.updateSoundName();
+                            }
+                        }
+                        Timer {
+                            id: synthButtonSoundNameThrottle
+                            interval: 0; repeat: false; running: false;
+                            onTriggered: {
+                                synthButton.text = zynqtgui.curlayerEngineName.length > 0 ? zynqtgui.curlayerEngineName : "";
+                            }
+                        }
+                        function updateSoundName() {
+                            synthButtonSoundNameThrottle.restart();
+                        }
+                    }
+                    Zynthian.BreadcrumbButton {
+                        id: presetButton
+                        icon.color: Kirigami.Theme.textColor
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 6
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                        visible: root.selectedChannel.trackType === "synth" && synthButton.visible
+                        onClicked: {
+                            // Open synth edit page whjen preset button is clicked
+                            zynqtgui.current_screen_id = "control";
+                            zynqtgui.forced_screen_back = "sketchpad"
+                        }
+
+                        Connections {
+                            target: zynqtgui.fixed_layers
+                            onList_updated: presetButton.updateSoundName()
+                        }
+                        Component.onCompleted: presetButton.updateSoundName()
+
+                        function updateSoundName() {
+                            presetButtonTextThrottle.restart()
+                        }
+                        Timer {
+                            id: presetButtonTextThrottle
+                            interval: 0; running: false; repeat: false;
+                            onTriggered: {
+                                presetButton.text = zynqtgui.curlayerPresetName.length > 0 ? zynqtgui.curlayerPresetName : qsTr("Presets");
+                            }
+                        }
+                    }
+                    Zynthian.BreadcrumbButton {
+                        icon.color: Kirigami.Theme.textColor
+                        text: {
+                            switch (effectScreen) {
+                            case "layer_midi_effects":
+                            case "midi_effect_types":
+                            case "layer_midi_effect_chooser":
+                                return "MIDI FX";
+                            default:
+                                "Audio FX";
+                            }
+                        }
+                        visible: {
+                            switch (zynqtgui.current_screen_id) {
+                            case "layer_effects":
+                            case "effect_types":
+                            case "layer_effect_chooser":
+                            case "layer_midi_effects":
+                            case "midi_effect_types":
+                            case "layer_midi_effect_chooser":
+                                return true;
+                            default:
+                                return false //screensLayer.depth > 2
+                            }
+                        }
+                        property string effectScreen: ""
+                        readonly property string screenId: zynqtgui.current_screen_id
+                        onScreenIdChanged: {
+                            switch (zynqtgui.current_screen_id) {
+                            case "layer_effects":
+                            case "effect_types":
+                            case "layer_effect_chooser":
+                            case "layer_midi_effects":
+                            case "midi_effect_types":
+                            case "layer_midi_effect_chooser":
+                                effectScreen = zynqtgui.current_screen_id;
+                            default:
+                                break;
+                            }
+                        }
+                        onClicked: zynqtgui.current_screen_id = effectScreen
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 8
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
+                    }
+                    Zynthian.BreadcrumbButton {
+                        icon.color: Kirigami.Theme.textColor
+                        text: "EDIT"
+                        visible: zynqtgui.current_screen_id === "control"
+                        Layout.maximumWidth: Kirigami.Units.gridUnit * 4
+                        rightPadding: Kirigami.Units.largeSpacing*2
+                        font.pointSize: 11
                     }
                 }
             }
-        }
-        Zynthian.BreadcrumbButton {
-            id: sampleLoopButton
 
-            property QtObject clip: zynqtgui.sketchpad.song.getClip(zynqtgui.sketchpad.selectedTrackId, zynqtgui.sketchpad.song.scenesModel.selectedSketchpadSongIndex)
-
-            icon.color: Kirigami.Theme.textColor
-            text: qsTr("%1").arg(clip && clip.filename ? clip.filename : "")
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 10
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            visible: root.selectedChannel.trackType === "sample-loop"
-        }
-        Zynthian.BreadcrumbButton {
-            id: synthButton
-            icon.color: Kirigami.Theme.textColor
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 6
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            visible: root.selectedChannel.trackType === "synth" && zynqtgui.curlayerEngineName.length > 0
-            Component.onCompleted: synthButton.updateSoundName();
-            // Open preset screen on clicking this synth button
-            onClicked: {
-                if (zynqtgui.curlayerIsFX) {
-                    zynqtgui.show_screen("effect_preset")
-                } else {
-                    zynqtgui.show_screen("preset")
-                }
+            Item {
+                Layout.fillWidth: true
             }
 
-            Connections {
-                target: zynqtgui.fixed_layers
-                onList_updated: {
-                    synthButton.updateSoundName();
-                }
-            }
-            Timer {
-                id: synthButtonSoundNameThrottle
-                interval: 0; repeat: false; running: false;
-                onTriggered: {
-                    synthButton.text = zynqtgui.curlayerEngineName.length > 0 ? zynqtgui.curlayerEngineName : "";
-                }
-            }
-            function updateSoundName() {
-                synthButtonSoundNameThrottle.restart();
-            }
-        }
-        Zynthian.BreadcrumbButton {
-            id: presetButton
-            icon.color: Kirigami.Theme.textColor
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 6
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-            visible: root.selectedChannel.trackType === "synth" && synthButton.visible
-            onClicked: {
-                // Open synth edit page whjen preset button is clicked
-                zynqtgui.current_screen_id = "control";
-                zynqtgui.forced_screen_back = "sketchpad"
-            }
+            QQC2.Control
+            {
+                Layout.fillHeight: true
+                Layout.margins: Kirigami.Units.smallSpacing
+                padding: 0
 
-            Connections {
-                target: zynqtgui.fixed_layers
-                onList_updated: presetButton.updateSoundName()
-            }
-            Component.onCompleted: presetButton.updateSoundName()
+                background: null
 
-            function updateSoundName() {
-                presetButtonTextThrottle.restart()
-            }
-            Timer {
-                id: presetButtonTextThrottle
-                interval: 0; running: false; repeat: false;
-                onTriggered: {
-                    presetButton.text = zynqtgui.curlayerPresetName.length > 0 ? zynqtgui.curlayerPresetName : qsTr("Presets");
-                }
-            }
-        }
-        Zynthian.BreadcrumbButton {
-            icon.color: Kirigami.Theme.textColor
-            text: {
-                switch (effectScreen) {
-                case "layer_midi_effects":
-                case "midi_effect_types":
-                case "layer_midi_effect_chooser":
-                    return "MIDI FX";
-                default:
-                    "Audio FX";
-                }
-            }
-            visible: {
-                switch (zynqtgui.current_screen_id) {
-                case "layer_effects":
-                case "effect_types":
-                case "layer_effect_chooser":
-                case "layer_midi_effects":
-                case "midi_effect_types":
-                case "layer_midi_effect_chooser":
-                    return true;
-                default:
-                    return false //screensLayer.depth > 2
-                }
-            }
-            property string effectScreen: ""
-            readonly property string screenId: zynqtgui.current_screen_id
-            onScreenIdChanged: {
-                switch (zynqtgui.current_screen_id) {
-                case "layer_effects":
-                case "effect_types":
-                case "layer_effect_chooser":
-                case "layer_midi_effects":
-                case "midi_effect_types":
-                case "layer_midi_effect_chooser":
-                    effectScreen = zynqtgui.current_screen_id;
-                default:
-                    break;
-                }
-            }
-            onClicked: zynqtgui.current_screen_id = effectScreen
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 8
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-        }
-        Zynthian.BreadcrumbButton {
-            icon.color: Kirigami.Theme.textColor
-            text: "EDIT"
-            visible: zynqtgui.current_screen_id === "control"
-            Layout.maximumWidth: Kirigami.Units.gridUnit * 4
-            rightPadding: Kirigami.Units.largeSpacing*2
-            font.pointSize: 11
-        }
-        Item {
-            Layout.fillWidth: true
-        }
+                contentItem: Row {
+                    spacing: Kirigami.Units.smallSpacing
 
-        QQC2.Button {
-            id: globalRecordButton
-            Layout.preferredWidth: Kirigami.Units.gridUnit*4
-            Layout.preferredHeight: Kirigami.Units.gridUnit*2
-            property QtObject currentSequence: Zynthbox.PlayGridManager.getSequenceModel(zynqtgui.sketchpad.song.scenesModel.selectedSequenceName)
-            onClicked: {
-                // handle live-recording-is-going state here, otherwise you might turn it
-                // on in the sequencer, then head out, and try and turn it off and it just
-                // opens the recording popup, which isn't what you'd be after
-                if (globalRecordButton.currentSequence.activePatternObject && globalRecordButton.currentSequence.activePatternObject.recordLive) {
-                    globalRecordButton.currentSequence.activePatternObject.recordLive = false;
-                    if (Zynthbox.PlayGridManager.metronomeActive) {
-                        Zynthian.CommonUtils.stopMetronomeAndPlayback();
+                    QQC2.Button {
+                        id: globalRecordButton
+                        width: Kirigami.Units.gridUnit*4
+                        height: parent.height
+                        property QtObject currentSequence: Zynthbox.PlayGridManager.getSequenceModel(zynqtgui.sketchpad.song.scenesModel.selectedSequenceName)
+                        onClicked: {
+                            // handle live-recording-is-going state here, otherwise you might turn it
+                            // on in the sequencer, then head out, and try and turn it off and it just
+                            // opens the recording popup, which isn't what you'd be after
+                            if (globalRecordButton.currentSequence.activePatternObject && globalRecordButton.currentSequence.activePatternObject.recordLive) {
+                                globalRecordButton.currentSequence.activePatternObject.recordLive = false;
+                                if (Zynthbox.PlayGridManager.metronomeActive) {
+                                    Zynthian.CommonUtils.stopMetronomeAndPlayback();
+                                }
+                            } else {
+                                applicationWindow().openRecordingPopup();
+                            }
+                        }
+
+                        icon.name: "media-record-symbolic"
+                        icon.width: 24
+                        icon.height: 24
+                        icon.color:  globalRecordButton.currentSequence.activePatternObject && globalRecordButton.currentSequence.activePatternObject.recordLive
+                                     ? "#ff5cf436" // A green with the same values as the red audio record colour below
+                                     : zynqtgui.sketchpad.isRecording ? "#fff44336" : Kirigami.Theme.textColor
                     }
-                } else {
-                    applicationWindow().openRecordingPopup();
+
+                    QQC2.Button {
+                        id: globalPlaybackButton
+                        width: Kirigami.Units.gridUnit*4
+                        height: parent.height
+                        onClicked: {
+                            if (zynqtgui.sketchpad.isMetronomeRunning) {
+                                zynqtgui.callable_ui_action_simple("SWITCH_STOP");
+                            } else {
+                                zynqtgui.callable_ui_action_simple("SWITCH_PLAY");
+                            }
+                        }
+
+                        icon.name: zynqtgui.sketchpad.isMetronomeRunning ? "media-playback-stop" : "media-playback-start"
+                        icon.width: 24
+                        icon.height: 24
+                        icon.color: Kirigami.Theme.textColor
+                    }
                 }
             }
 
-            Kirigami.Icon {
-                width: Kirigami.Units.gridUnit
-                height: width
-                anchors.centerIn: parent
-                source: "media-record-symbolic"
-                color: globalRecordButton.currentSequence.activePatternObject && globalRecordButton.currentSequence.activePatternObject.recordLive
-                    ? "#ff5cf436" // A green with the same values as the red audio record colour below
-                    : zynqtgui.sketchpad.isRecording ? "#fff44336" : "white"
-            }
-        }
-        QQC2.Button {
-            Layout.preferredWidth: Kirigami.Units.gridUnit*4
-            Layout.preferredHeight: Kirigami.Units.gridUnit*2
-            onClicked: {
-                if (zynqtgui.sketchpad.isMetronomeRunning) {
-                    zynqtgui.callable_ui_action_simple("SWITCH_STOP");
-                } else {
-                    zynqtgui.callable_ui_action_simple("SWITCH_PLAY");
-                }
+            Item {
+                Layout.fillWidth: true
             }
 
-            Kirigami.Icon {
-                width: Kirigami.Units.gridUnit
-                height: width
-                anchors.centerIn: parent
-                source: zynqtgui.sketchpad.isMetronomeRunning ? "media-playback-stop" : "media-playback-start"
-                color: "white"
+            Zynthian.StatusInfo {
+                highlighted: zynqtgui.sketchpad.isMetronomeRunning
             }
         }
-
-        Zynthian.StatusInfo {}
     }
+
     background: Rectangle {
         Kirigami.Theme.inherit: false
         // TODO: this should eventually go to Window and the panels to View
@@ -1375,62 +1430,62 @@ Kirigami.AbstractApplicationWindow {
             var returnVal = false
 
             switch (cuia) {
-                case "TRACK_1":
-                    clipBar.handleItemClick(0);
-                    returnVal = true;
-                    break
-                case "TRACK_2":
-                    clipBar.handleItemClick(1);
-                    returnVal = true;
-                    break
-                case "TRACK_3":
-                    clipBar.handleItemClick(2);
-                    returnVal = true;
-                    break
-                case "TRACK_4":
-                    clipBar.handleItemClick(3);
-                    returnVal = true;
-                    break
-                case "TRACK_5":
-                    clipBar.handleItemClick(4);
-                    returnVal = true;
-                    break
-                case "SELECT_UP":
-                    returnVal = true
-                    break
-                case "SELECT_DOWN":
-                    returnVal = true
-                    break
-                case "NAVIGATE_LEFT":
-                    returnVal = true
-                    break
-                case "NAVIGATE_RIGHT":
-                    returnVal = true
-                    break
-                case "KNOB0_UP":
-                    returnVal = true
-                    break
-                case "KNOB0_DOWN":
-                    returnVal = true
-                    break
-                case "KNOB1_UP":
-                    returnVal = true
-                    break
-                case "KNOB1_DOWN":
-                    returnVal = true
-                    break
-                case "KNOB2_UP":
-                    returnVal = true
-                    break
-                case "KNOB2_DOWN":
-                    returnVal = true
-                    break
-                case "KNOB3_UP":
-                    returnVal = true
-                    break
-                case "KNOB3_DOWN":
-                    returnVal = true
-                    break
+            case "TRACK_1":
+                clipBar.handleItemClick(0);
+                returnVal = true;
+                break
+            case "TRACK_2":
+                clipBar.handleItemClick(1);
+                returnVal = true;
+                break
+            case "TRACK_3":
+                clipBar.handleItemClick(2);
+                returnVal = true;
+                break
+            case "TRACK_4":
+                clipBar.handleItemClick(3);
+                returnVal = true;
+                break
+            case "TRACK_5":
+                clipBar.handleItemClick(4);
+                returnVal = true;
+                break
+            case "SELECT_UP":
+                returnVal = true
+                break
+            case "SELECT_DOWN":
+                returnVal = true
+                break
+            case "NAVIGATE_LEFT":
+                returnVal = true
+                break
+            case "NAVIGATE_RIGHT":
+                returnVal = true
+                break
+            case "KNOB0_UP":
+                returnVal = true
+                break
+            case "KNOB0_DOWN":
+                returnVal = true
+                break
+            case "KNOB1_UP":
+                returnVal = true
+                break
+            case "KNOB1_DOWN":
+                returnVal = true
+                break
+            case "KNOB2_UP":
+                returnVal = true
+                break
+            case "KNOB2_DOWN":
+                returnVal = true
+                break
+            case "KNOB3_UP":
+                returnVal = true
+                break
+            case "KNOB3_DOWN":
+                returnVal = true
+                break
             }
 
             return returnVal;


### PR DESCRIPTION
This PR includes:
- The header has three distinguish sections now wrapped into singular controls: breadcrumbs, playback buttons, and status info. This is beneficial to later target a section for consistent styling and feels more organized.
- The section elements now have a consistent usage of padding and spacing. Other UI elements were using the `Kirigami.Units.smallSpacing`, so here I'm reusing it. 
- The header is also wrapped into a Panel, so it can have a background